### PR TITLE
Feature/cast coverage values to int

### DIFF
--- a/decision_rules/classification/prediction_indicators.py
+++ b/decision_rules/classification/prediction_indicators.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 import warnings
 
 import numpy as np
+import math
 from decision_rules.problem import ProblemTypes
 from imblearn.metrics import geometric_mean_score
 from sklearn.metrics import accuracy_score
@@ -181,17 +182,17 @@ def calculate_class_indicators_classification(
         ClassificationPredictionIndicatorsForClass: A dictionary representing
         the calculated prediction indicators for the class.
     """
-    TP: int = np.count_nonzero(np.logical_and(y_true == cls, y_pred == cls))
-    FN: int = np.count_nonzero(np.logical_and(y_true == cls, y_pred != cls))
-    FP: int = np.count_nonzero(np.logical_and(y_true != cls, y_pred == cls))
-    TN: int = np.count_nonzero(np.logical_and(y_true != cls, y_pred != cls))
+    TP: int = int(np.count_nonzero(np.logical_and(y_true == cls, y_pred == cls)))
+    FN: int = int(np.count_nonzero(np.logical_and(y_true == cls, y_pred != cls)))
+    FP: int = int(np.count_nonzero(np.logical_and(y_true != cls, y_pred == cls)))
+    TN: int = int(np.count_nonzero(np.logical_and(y_true != cls, y_pred != cls)))
     Precision: float = TP / (TP + FP) if (TP + FP) != 0 else 0
     Recall: float = TP / (TP + FN) if (TP + FN) != 0 else 0
     Specificity: float = TN / (TN + FP) if (TN + FP) != 0 else 0
     F1_score: float = 2 * (Precision * Recall) / \
         (Precision + Recall) if (Precision + Recall) != 0 else 0
-    G_mean: float = np.sqrt(Recall * Specificity)
-    MCC: float = (TP * TN - FP * FN) / np.sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN)) if (TP + FP) * (TP + FN) * (
+    G_mean: float = math.sqrt(Recall * Specificity)
+    MCC: float = (TP * TN - FP * FN) / math.sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN)) if (TP + FP) * (TP + FN) * (
         TN + FP) * (TN + FN) != 0 else 0
     PPV: float = TP / (TP + FP) if (TP + FP) != 0 else 0
     NPV: float = TN / (TN + FN) if (TN + FN) != 0 else 0

--- a/decision_rules/core/coverage.py
+++ b/decision_rules/core/coverage.py
@@ -24,10 +24,12 @@ class Coverage:
     N: int
 
     def __init__(self, p: int, n: int, P: int, N: int):
-        self.p = p
-        self.n = n
-        self.P = P
-        self.N = N
+        # input values may actually come from numpy calculations,
+        # so we need to coerce them to python integers in order to avoid overflow
+        self.p = int(p) if p is not None else None
+        self.n = int(n) if n is not None else None
+        self.P = int(P) if P is not None else None
+        self.N = int(N) if N is not None else None
         self._validate()
 
     def _validate(self):

--- a/decision_rules/core/rule.py
+++ b/decision_rules/core/rule.py
@@ -236,8 +236,8 @@ class AbstractRule(ABC):
 
     def get_coverage_dict(self) -> dict:
         return {
-            "p": int(self.coverage.p),
-            "n": int(self.coverage.n),
-            "P": int(self.coverage.P),
-            "N": int(self.coverage.N)
+            "p": self.coverage.p,
+            "n": self.coverage.n,
+            "P": self.coverage.P,
+            "N": self.coverage.N
         }


### PR DESCRIPTION
During development of RuleMiner, a problem arose with large datasets where calculating some prediction indicators based on coverage values raised errors. The reason was integer overflow in multiplication of several very large `np.int64`-type values. Based on tests with a large dataset (ca. 250,000 rows), I identified all places where `np.int64`-type values are obtained (as results of aggregate functions on `numpy` arrays) and processed, and coerced them to pythonic `int` type. These subsequent (previously) problematic multiplications are all scalar operations, so according to my knowledge, there should not be any disadvantage in terms of calculation efficiency (in fact, the opposite may be true). With changes introduced in this PR, no further overflow errors have been identified in rule generation and indicator calculation processes.