### PR TITLE
correct classification metrics for empty rules

### DIFF
--- a/decision_rules/classification/metrics.py
+++ b/decision_rules/classification/metrics.py
@@ -6,12 +6,13 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+from scipy.stats import fisher_exact
+from scipy.stats import hypergeom
+
 from decision_rules import measures
 from decision_rules.classification.rule import ClassificationRule
 from decision_rules.core.coverage import Coverage
 from decision_rules.core.metrics import AbstractRulesMetrics
-from scipy.stats import fisher_exact
-from scipy.stats import hypergeom
 
 
 class ClassificationRulesMetrics(AbstractRulesMetrics):
@@ -111,6 +112,8 @@ class ClassificationRulesMetrics(AbstractRulesMetrics):
         coverage: Coverage = rule.coverage
         tn: int = coverage.N - coverage.n
         fn: int = coverage.P - coverage.p
+        if (fn + tn) == 0:
+            return float('nan')
         return tn / (fn + tn)
 
     def calculate_p_value(self, coverage: Optional[Coverage] = None, rule: Optional[ClassificationRule] = None, y: Optional[np.ndarray] = None) -> float:

--- a/tests/base_tests/classification/test_rule.py
+++ b/tests/base_tests/classification/test_rule.py
@@ -2,8 +2,11 @@
 import unittest
 
 import numpy as np
+
+from decision_rules.classification.metrics import ClassificationRulesMetrics
 from decision_rules.classification.rule import ClassificationConclusion
 from decision_rules.classification.rule import ClassificationRule
+from decision_rules.conditions import CompoundCondition
 from decision_rules.core.coverage import Coverage
 from tests.base_tests.core.test_abstract_condition import TestingCondition
 
@@ -42,6 +45,22 @@ class TestClassificationRule(unittest.TestCase):
             coverage.n, expected_n,
             'Should calculate n correctly'
         )
+
+
+class TestEmptyClassificationRuleMetrics(unittest.TestCase):
+    def test_empty_rule_metrics(self):
+        X = np.array([[1, 2], [3, 4], [5, 6]])
+        y = np.array([0, 1, 0])
+        rule = ClassificationRule(
+            CompoundCondition([]),
+            ClassificationConclusion("", 'label'),
+            []
+        )
+        rule.coverage = Coverage(3, 3, 3, 3)
+        metrics_calculator = ClassificationRulesMetrics([rule])
+        metrics = metrics_calculator.calculate(X, y)
+        self.assertTrue(
+            np.isnan(metrics[rule.uuid]["negative_predictive_value"]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed handling of edge cases in negative predictive value calculation. I also added a test to make sure no other metrics are problematic for an empty rule.