### PR TITLE
Calling update() no longer required after model's deserialization

### DIFF
--- a/decision_rules/core/coverage.py
+++ b/decision_rules/core/coverage.py
@@ -1,6 +1,7 @@
 """
 Contains rule coverage class
 """
+
 from typing import TypedDict
 
 
@@ -36,20 +37,20 @@ class Coverage:
         if any(e is None for e in self.as_tuple()):
             return
         if self.p > self.P:
-            raise InvalidCoverageError('Invalid coverage: p is greater than P')
+            raise InvalidCoverageError("Invalid coverage: p is greater than P")
         if self.n > self.N:
-            raise InvalidCoverageError('Invalid coverage: n is greater than N')
+            raise InvalidCoverageError("Invalid coverage: n is greater than N")
 
     def as_tuple(self) -> tuple[int, int, int, int]:
         return (self.p, self.n, self.P, self.N)
-    
+
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, Coverage):
             return False
         return self.as_tuple() == value.as_tuple()
 
     def __str__(self) -> str:
-        return f'(p={self.p}, n={self.n}, P={self.P}, N={self.N})'
+        return f"(p={self.p}, n={self.n}, P={self.P}, N={self.N})"
 
 
 class ClassificationCoverageInfodict(TypedDict):

--- a/decision_rules/core/coverage.py
+++ b/decision_rules/core/coverage.py
@@ -42,6 +42,11 @@ class Coverage:
 
     def as_tuple(self) -> tuple[int, int, int, int]:
         return (self.p, self.n, self.P, self.N)
+    
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Coverage):
+            return False
+        return self.as_tuple() == value.as_tuple()
 
     def __str__(self) -> str:
         return f'(p={self.p}, n={self.n}, P={self.P}, N={self.N})'

--- a/decision_rules/core/rule.py
+++ b/decision_rules/core/rule.py
@@ -1,6 +1,7 @@
 """
 Contains abstract rule and conclusion classes.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -20,11 +21,7 @@ class AbstractConclusion(ABC):
         ABC (_type_): _description_
     """
 
-    def __init__(
-        self,
-        value: Any,
-        column_name: str
-    ) -> None:
+    def __init__(self, value: Any, column_name: str) -> None:
         self.value: Any = value
         self.column_name: str = column_name
 
@@ -54,7 +51,9 @@ class AbstractConclusion(ABC):
 
     @staticmethod
     @abstractmethod
-    def make_empty(column_name: str) -> AbstractConclusion:  # pylint: disable=invalid-name
+    def make_empty(
+        column_name: str,
+    ) -> AbstractConclusion:  # pylint: disable=invalid-name
         """Creates empty conclusion. Use it when you don't want to use default conclusion during
         prediction.
 
@@ -71,9 +70,9 @@ class AbstractConclusion(ABC):
 
     def __eq__(self, other: object) -> bool:
         return (
-            isinstance(other, AbstractConclusion) and
-            other.column_name == self.column_name and
-            other.value == self.value
+            isinstance(other, AbstractConclusion)
+            and other.column_name == self.column_name
+            and other.value == self.value
         )
 
     @abstractmethod
@@ -96,7 +95,7 @@ class AbstractRule(ABC):
         self,
         premise: AbstractCondition,
         conclusion: AbstractConclusion,
-        column_names: list[str]
+        column_names: list[str],
     ) -> None:
         """
         Args:
@@ -121,11 +120,7 @@ class AbstractRule(ABC):
         return self._uuid
 
     def calculate_coverage(
-        self,
-        X: np.ndarray,
-        y: np.ndarray = None,
-        P: int = None,
-        N: int = None
+        self, X: np.ndarray, y: np.ndarray = None, P: int = None, N: int = None
     ) -> Coverage:
         """
         Args:
@@ -145,11 +140,10 @@ class AbstractRule(ABC):
         """
         if y is None and (P is None or N is None):
             raise ValueError(
-                'Either "y" parameter or both "P" and "N" parameters should be passed' +
-                'to this method. All of them were None'
+                'Either "y" parameter or both "P" and "N" parameters should be passed'
+                + "to this method. All of them were None"
             )
-        P: int = y[self.conclusion.positives_mask(
-            y)].shape[0] if P is None else P
+        P: int = y[self.conclusion.positives_mask(y)].shape[0] if P is None else P
         N: int = y.shape[0] - P if y is not None else N
 
         with self.premise.cache(recursive=False):
@@ -221,23 +215,23 @@ class AbstractRule(ABC):
 
     def __eq__(self, other: object) -> bool:
         return (
-            isinstance(other, AbstractRule) and
-            self.conclusion == other.conclusion and
-            self.premise == other.premise
+            isinstance(other, AbstractRule)
+            and self.conclusion == other.conclusion
+            and self.premise == other.premise
         )
 
     def __str__(self, show_coverage: bool = True) -> str:
         condition_str: str = self.premise.to_string(self.column_names)
         if self.coverage is not None and show_coverage:
-            coverage_str: str = f' {str(self.coverage)}'
+            coverage_str: str = f" {str(self.coverage)}"
         else:
-            coverage_str = ''
-        return f'IF {condition_str} THEN {str(self.conclusion)}{coverage_str}'.strip()
+            coverage_str = ""
+        return f"IF {condition_str} THEN {str(self.conclusion)}{coverage_str}".strip()
 
     def get_coverage_dict(self) -> dict:
         return {
             "p": self.coverage.p,
             "n": self.coverage.n,
             "P": self.coverage.P,
-            "N": self.coverage.N
+            "N": self.coverage.N,
         }

--- a/decision_rules/core/rule.py
+++ b/decision_rules/core/rule.py
@@ -3,12 +3,12 @@ Contains abstract rule and conclusion classes.
 """
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any
 from uuid import uuid4
 
 import numpy as np
+
 from decision_rules.core.condition import AbstractCondition
 from decision_rules.core.coverage import Coverage
 
@@ -109,7 +109,7 @@ class AbstractRule(ABC):
         self.conclusion: AbstractConclusion = conclusion
         self.premise: AbstractCondition = premise
         self.coverage: Coverage = None
-        self.voting_weight: float = 1.0
+        self.voting_weight: float = None
 
     @property
     def uuid(self) -> str:

--- a/decision_rules/core/ruleset.py
+++ b/decision_rules/core/ruleset.py
@@ -11,7 +11,8 @@ import numpy as np
 import pandas as pd
 
 from decision_rules.conditions import AttributesCondition, CompoundCondition
-from decision_rules.core.coverage import ClassificationCoverageInfodict, Coverage
+from decision_rules.core.coverage import (ClassificationCoverageInfodict,
+                                          Coverage)
 from decision_rules.core.exceptions import InvalidStateError
 from decision_rules.core.metrics import AbstractRulesMetrics
 from decision_rules.core.prediction import PredictionStrategy, _PredictionModel
@@ -52,7 +53,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         )
         if not voting_weights_calculated:
             raise InvalidStateError(
-                "Rules coverages must have been calculated before prediction."
+                "Rule coverages have to be calculated before performing prediction."
                 + "Did you forget to call update(...) method?"
             )
 
@@ -71,7 +72,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         if self._stored_default_conclusion is None:
             raise InvalidStateError(
                 "Default conclusion was never configured."
-                + "Call update(...) method to calculated automatic default conclusion "
+                + "Call update(...) method to calculate automatic default conclusion "
                 + "or set it manually."
             )
         self._use_default_conclusion = enabled

--- a/decision_rules/core/ruleset.py
+++ b/decision_rules/core/ruleset.py
@@ -1,6 +1,7 @@
 """
 Contains abstract ruleset class.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -10,8 +11,7 @@ import numpy as np
 import pandas as pd
 
 from decision_rules.conditions import AttributesCondition, CompoundCondition
-from decision_rules.core.coverage import (ClassificationCoverageInfodict,
-                                          Coverage)
+from decision_rules.core.coverage import ClassificationCoverageInfodict, Coverage
 from decision_rules.core.exceptions import InvalidStateError
 from decision_rules.core.metrics import AbstractRulesMetrics
 from decision_rules.core.prediction import PredictionStrategy, _PredictionModel
@@ -20,13 +20,9 @@ from decision_rules.measures import coverage, precision
 
 
 class AbstractRuleSet(_PredictionModel, ABC):
-    """Abstract ruleset allowing to perform prediction on data
-    """
+    """Abstract ruleset allowing to perform prediction on data"""
 
-    def __init__(
-        self,
-        rules: list[AbstractRule]
-    ) -> None:
+    def __init__(self, rules: list[AbstractRule]) -> None:
         """
         Args:
             rules (list[AbstractRule]):
@@ -51,17 +47,19 @@ class AbstractRuleSet(_PredictionModel, ABC):
         return None
 
     def _validate_object_state_before_prediction(self):
-        voting_weights_calculated: bool = all([
-            rule.coverage is not None for rule in self.rules
-        ])
+        voting_weights_calculated: bool = all(
+            [rule.coverage is not None for rule in self.rules]
+        )
         if not voting_weights_calculated:
             raise InvalidStateError(
-                'Rules coverages must have been calculated before prediction.' +
-                'Did you forget to call update(...) method?'
+                "Rules coverages must have been calculated before prediction."
+                + "Did you forget to call update(...) method?"
             )
 
     @abstractmethod
-    def _calculate_P_N(self, y_uniques: np.ndarray, y_values_count: np.ndarray):  # pylint: disable=invalid-name
+    def _calculate_P_N(
+        self, y_uniques: np.ndarray, y_values_count: np.ndarray
+    ):  # pylint: disable=invalid-name
         pass
 
     def set_default_conclusion_enabled(self, enabled: bool) -> None:
@@ -72,16 +70,18 @@ class AbstractRuleSet(_PredictionModel, ABC):
         """
         if self._stored_default_conclusion is None:
             raise InvalidStateError(
-                'Default conclusion was never configured.' +
-                'Call update(...) method to calculated automatic default conclusion ' +
-                'or set it manually.'
+                "Default conclusion was never configured."
+                + "Call update(...) method to calculated automatic default conclusion "
+                + "or set it manually."
             )
         self._use_default_conclusion = enabled
         if enabled:
             self.default_conclusion = self._stored_default_conclusion
         else:
-            self.default_conclusion = self._stored_default_conclusion.__class__.make_empty(
-                self.decision_attribute
+            self.default_conclusion = (
+                self._stored_default_conclusion.__class__.make_empty(
+                    self.decision_attribute
+                )
             )
 
     @property
@@ -109,29 +109,33 @@ class AbstractRuleSet(_PredictionModel, ABC):
         """
         return self._use_default_conclusion
 
-    def _validate_coverage_matrix_param(self, X_binary: np.ndarray):  # pylint: disable=invalid-name
-        BASE_VALIDATION_ERROR_MESSAGE: str = 'Coverage matrix must be a 2D boolean numpy array.'  # pylint: disable=invalid-name
+    def _validate_coverage_matrix_param(
+        self, X_binary: np.ndarray
+    ):  # pylint: disable=invalid-name
+        BASE_VALIDATION_ERROR_MESSAGE: str = (
+            "Coverage matrix must be a 2D boolean numpy array."  # pylint: disable=invalid-name
+        )
         if not isinstance(X_binary, np.ndarray):
             raise ValueError(
-                BASE_VALIDATION_ERROR_MESSAGE +
-                f' Passed object is of type "{str(type(X_binary))}".'
+                BASE_VALIDATION_ERROR_MESSAGE
+                + f' Passed object is of type "{str(type(X_binary))}".'
             )
         if len(X_binary.shape) != 2:
             raise ValueError(
-                BASE_VALIDATION_ERROR_MESSAGE +
-                f' Passed array have shape = {X_binary.shape}.'
+                BASE_VALIDATION_ERROR_MESSAGE
+                + f" Passed array have shape = {X_binary.shape}."
             )
         if X_binary.dtype != bool:
             raise ValueError(
-                BASE_VALIDATION_ERROR_MESSAGE +
-                f' Passed array have dtype {X_binary.dtype}.'
+                BASE_VALIDATION_ERROR_MESSAGE
+                + f" Passed array have dtype {X_binary.dtype}."
             )
 
     def _sanitize_dataset(
         self,
         X: Union[np.ndarray, pd.DataFrame],
         y: Optional[Union[np.ndarray, pd.Series]] = None,
-        to_numpy: bool = True
+        to_numpy: bool = True,
     ) -> Union[tuple[np.ndarray, np.ndarray], np.ndarray]:
         """Sanitize and prepare dataset for other operations. Decision rules internally
         works on numpy arrays instead of pandas dataframes to improve execution times.
@@ -147,11 +151,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
             Union[tuple[np.ndarray, np.ndarray], np.ndarray]: _description_
         """
         if isinstance(X, pd.DataFrame) or isinstance(X, pd.Series):
-            X = (
-                X[self.column_names]
-                if self.column_names is not None
-                else X
-            )
+            X = X[self.column_names] if self.column_names is not None else X
             if to_numpy:
                 X = X.to_numpy()
         if isinstance(y, pd.Series) and to_numpy:
@@ -172,16 +172,16 @@ class AbstractRuleSet(_PredictionModel, ABC):
         X: np.ndarray = self._sanitize_dataset(X)
         if len(self.rules) == 0:
             return np.empty(shape=(X.shape[0], 0), dtype=bool)
-        coverage_matrix = np.array([
-            rule.premise.covered_mask(X) for rule in self.rules
-        ]).T
+        coverage_matrix = np.array(
+            [rule.premise.covered_mask(X) for rule in self.rules]
+        ).T
         return coverage_matrix
 
     def calculate_rules_coverages(
         self,
         X_train: Union[np.ndarray, pd.DataFrame],
         y_train: Union[np.ndarray, pd.Series],
-        **kwargs
+        **kwargs,
     ) -> np.ndarray:
         """
         Args:
@@ -197,27 +197,27 @@ class AbstractRuleSet(_PredictionModel, ABC):
         self._calculate_P_N(*np.unique(y_train, return_counts=True))
 
         coverage_matrix: np.ndarray = np.empty(
-            shape=(X_train.shape[0], len(self.rules)),
-            dtype=bool
+            shape=(X_train.shape[0], len(self.rules)), dtype=bool
         )
         for i, rule in enumerate(self.rules):
-            P: int = self.train_P[rule.conclusion.value] if self.train_P is not None else None
-            N: int = self.train_N[rule.conclusion.value] if self.train_N is not None else None
+            P: int = (
+                self.train_P[rule.conclusion.value]
+                if self.train_P is not None
+                else None
+            )
+            N: int = (
+                self.train_N[rule.conclusion.value]
+                if self.train_N is not None
+                else None
+            )
             with rule.premise.cache(recursive=False):
                 rule.coverage = rule.calculate_coverage(
-                    X_train,
-                    y_train,
-                    P=P,
-                    N=N,
-                    **kwargs
+                    X_train, y_train, P=P, N=N, **kwargs
                 )
                 coverage_matrix[:, i] = rule.premise.covered_mask(X_train)
         return coverage_matrix
 
-    def calculate_rules_weights(
-        self,
-        measure: Callable[[Coverage], float]
-    ):
+    def calculate_rules_weights(self, measure: Callable[[Coverage], float]):
         """
         Args:
             measure (Callable[[Coverage], float]): quality measure function
@@ -228,10 +228,10 @@ class AbstractRuleSet(_PredictionModel, ABC):
         for rule in self.rules:
             if rule.coverage is None:
                 raise ValueError(
-                    'Tried to calculate voting weight of a rule with uncalculated coverage.' +
-                    'You should either call `RuleSet.calculate_rules_coverages` method - to ' +
-                    'calculate coverages of all rules - or call `Rule.calculate_coverage` ' +
-                    '- to calculate coverage of this specific rule'
+                    "Tried to calculate voting weight of a rule with uncalculated coverage."
+                    + "You should either call `RuleSet.calculate_rules_coverages` method - to "
+                    + "calculate coverages of all rules - or call `Rule.calculate_coverage` "
+                    + "- to calculate coverage of this specific rule"
                 )
             rule.voting_weight = measure(rule.coverage)
         self._voting_weights_calculated = True
@@ -240,7 +240,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         self,
         y_uniques: np.ndarray,
         y_values_count: np.ndarray,
-        measure: Callable[[Coverage], float]
+        measure: Callable[[Coverage], float],
     ):
         self._calculate_P_N(y_uniques, y_values_count)
         self.calculate_rules_weights(measure)
@@ -263,40 +263,40 @@ class AbstractRuleSet(_PredictionModel, ABC):
             )
         if len(self.rules) != len(coverages_info):
             raise ValueError(
-                'Length of coverage_info should be the same as number ' +
-                f'of rules in ruleset ({len(self.rules)}), is: {len(coverages_info)}'
+                "Length of coverage_info should be the same as number "
+                + f"of rules in ruleset ({len(self.rules)}), is: {len(coverages_info)}"
             )
-        self.column_names = columns_names if columns_names is not None else self.column_names
+        self.column_names = (
+            columns_names if columns_names is not None else self.column_names
+        )
         y_uniques: list[Any] = []
         y_values_count: list[Any] = []
         for rule in self.rules:
             try:
-                coverage_info: ClassificationCoverageInfodict = coverages_info[rule.uuid]
+                coverage_info: ClassificationCoverageInfodict = coverages_info[
+                    rule.uuid
+                ]
                 rule.coverage = Coverage(
-                    p=coverage_info['p'],
-                    n=coverage_info['n'],
-                    P=coverage_info['P'],
-                    N=coverage_info['N']
+                    p=coverage_info["p"],
+                    n=coverage_info["n"],
+                    P=coverage_info["P"],
+                    N=coverage_info["N"],
                 )
                 if rule.conclusion.value not in y_uniques:
                     y_uniques.append(rule.conclusion.value)
                     y_values_count.append(rule.coverage.P)
             except KeyError:
                 raise ValueError(  # pylint: disable=raise-missing-from
-                    f'Coverage info missing for rule: "{rule.uuid}" ' +
-                    'and possibly some other rules too.'
+                    f'Coverage info missing for rule: "{rule.uuid}" '
+                    + "and possibly some other rules too."
                 )
-        self._base_update(
-            np.array(y_uniques),
-            np.array(y_values_count),
-            measure
-        )
+        self._base_update(np.array(y_uniques), np.array(y_values_count), measure)
 
     def update(
         self,
         X_train: pd.DataFrame,
         y_train: pd.Series,
-        measure: Callable[[Coverage], float]
+        measure: Callable[[Coverage], float],
     ):
         """Updates ruleset using training dataset. This method should be called
         both after creation of new ruleset or after manipulating any of its rules
@@ -319,15 +319,9 @@ class AbstractRuleSet(_PredictionModel, ABC):
             self.column_names = X_train.columns.tolist()
         X_train, y_train = self._sanitize_dataset(X_train, y_train)
         y_uniques, y_values_count = np.unique(y_train, return_counts=True)
-        coverage_matrix: np.ndarray = self.calculate_rules_coverages(
-            X_train, y_train
-        )
+        coverage_matrix: np.ndarray = self.calculate_rules_coverages(X_train, y_train)
 
-        self._base_update(
-            y_uniques,
-            y_values_count,
-            measure
-        )
+        self._base_update(y_uniques, y_values_count, measure)
         return coverage_matrix
 
     def predict(
@@ -349,7 +343,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         self,
         X: pd.DataFrame,  # pylint: disable=invalid-name
         y: pd.Series,  # pylint: disable=invalid-name
-        metrics_to_calculate: Optional[list[str]] = None
+        metrics_to_calculate: Optional[list[str]] = None,
     ) -> dict[dict[str, str, float]]:
         """Calculate rules metrics for each rule such as precision,
         coverage, TP, FP etc. This method should be called after updating
@@ -387,7 +381,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         self,
         X: pd.DataFrame,  # pylint: disable=invalid-name
         y: pd.Series,  # pylint: disable=invalid-name
-        measure: Callable[[Coverage], float]
+        measure: Callable[[Coverage], float],
     ) -> Union[dict[str, float], dict[str, dict[str, float]]]:
         """Calculate importances of conditions in RuleSet
 
@@ -403,9 +397,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
     @abstractmethod
     def calculate_attribute_importances(
         self,
-        condition_importances: Union[
-            dict[str, float], dict[str, dict[str, float]]
-        ]
+        condition_importances: Union[dict[str, float], dict[str, dict[str, float]]],
     ) -> Union[dict[str, float], dict[str, dict[str, float]]]:
         """Calculate importances of attriubtes in RuleSet based on conditions importances
 
@@ -426,26 +418,36 @@ class AbstractRuleSet(_PredictionModel, ABC):
         Returns:
             dict: RuleSet statistics
         """
+
         def count_conditions(condition) -> int:
             """Recursively count the leaf subconditions."""
             if not condition.subconditions:
                 return 1
-            return sum(count_conditions(subcondition) for subcondition in condition.subconditions)
+            return sum(
+                count_conditions(subcondition)
+                for subcondition in condition.subconditions
+            )
 
         stats = dict()
         stats["rules_count"] = len(self.rules)
         stats["avg_conditions_count"] = round(
-            np.mean([len(rule.premise.subconditions) for rule in self.rules]), 2)
+            np.mean([len(rule.premise.subconditions) for rule in self.rules]), 2
+        )
         stats["avg_precision"] = round(
-            np.mean([precision(rule.coverage) for rule in self.rules]), 2)
+            np.mean([precision(rule.coverage) for rule in self.rules]), 2
+        )
         stats["avg_coverage"] = round(
-            np.mean([coverage(rule.coverage) for rule in self.rules]), 2)
+            np.mean([coverage(rule.coverage) for rule in self.rules]), 2
+        )
         stats["total_conditions_count"] = sum(
-            [count_conditions(rule.premise) for rule in self.rules])
+            [count_conditions(rule.premise) for rule in self.rules]
+        )
 
         return stats
 
-    def local_explainability(self, x: pd.Series) -> tuple[list[str], str]:  # pylint: disable=invalid-name
+    def local_explainability(
+        self, x: pd.Series
+    ) -> tuple[list[str], str]:  # pylint: disable=invalid-name
         """Calculate local explainability of ruleset for given instance.
 
         Args:
@@ -460,16 +462,14 @@ class AbstractRuleSet(_PredictionModel, ABC):
         # TODO: here we can cache rules covered masks for improved performance
         prediction: np.ndarray = self.predict(x)
         rules_covering_instance = [
-            rule.uuid for rule in self.rules
+            rule.uuid
+            for rule in self.rules
             if np.sum(rule.premise.covered_mask(x)) == 1
         ]
         return rules_covering_instance, prediction
 
     def __eq__(self, other: object) -> bool:
-        return (
-            isinstance(other, AbstractRuleSet) and
-            other.rules == self.rules
-        )
+        return isinstance(other, AbstractRuleSet) and other.rules == self.rules
 
     def split_dataset(self, dataset: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series]:
         X = dataset.drop(columns=self.decision_attribute)
@@ -478,15 +478,11 @@ class AbstractRuleSet(_PredictionModel, ABC):
 
     @property
     def coverage_dict(self) -> dict:
-        return {
-            rule.uuid: rule.get_coverage_dict()
-            for rule in self.rules
-        }
+        return {rule.uuid: rule.get_coverage_dict() for rule in self.rules}
 
     def update_meta(self, new_attributes: list[str]):
         if set(self.column_names).difference(set(new_attributes)):
-            raise ValueError(
-                "New attributes do not contain all of the old attributes.")
+            raise ValueError("New attributes do not contain all of the old attributes.")
         old_to_new_attr_mapping = {
             i: new_attributes.index(attr) for i, attr in enumerate(self.column_names)
         }

--- a/decision_rules/core/ruleset.py
+++ b/decision_rules/core/ruleset.py
@@ -3,28 +3,20 @@ Contains abstract ruleset class.
 """
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
-from typing import Any
-from typing import Callable
-from typing import Optional
-from typing import Union
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
 
-from decision_rules.conditions import AttributesCondition
-from decision_rules.conditions import CompoundCondition
-from decision_rules.core.coverage import ClassificationCoverageInfodict
-from decision_rules.core.coverage import Coverage
+from decision_rules.conditions import AttributesCondition, CompoundCondition
+from decision_rules.core.coverage import (ClassificationCoverageInfodict,
+                                          Coverage)
 from decision_rules.core.exceptions import InvalidStateError
 from decision_rules.core.metrics import AbstractRulesMetrics
-from decision_rules.core.prediction import _PredictionModel
-from decision_rules.core.prediction import PredictionStrategy
-from decision_rules.core.rule import AbstractConclusion
-from decision_rules.core.rule import AbstractRule
-from decision_rules.measures import coverage
-from decision_rules.measures import precision
+from decision_rules.core.prediction import PredictionStrategy, _PredictionModel
+from decision_rules.core.rule import AbstractConclusion, AbstractRule
+from decision_rules.measures import coverage, precision
 
 
 class AbstractRuleSet(_PredictionModel, ABC):
@@ -52,7 +44,6 @@ class AbstractRuleSet(_PredictionModel, ABC):
         self._stored_default_conclusion: AbstractConclusion = None
         self._prediction_strategy: Optional[PredictionStrategy] = None
         self.decision_attribute: Optional[str] = None
-        self._voting_weights_calculated: bool = False
 
     @abstractmethod
     def get_metrics_object_instance(self) -> AbstractRulesMetrics:
@@ -60,7 +51,10 @@ class AbstractRuleSet(_PredictionModel, ABC):
         return None
 
     def _validate__object_state_before_prediction(self):
-        if not self._voting_weights_calculated:
+        voting_weights_calculated: bool = all([
+            rule.coverage is not None for rule in self.rules
+        ])
+        if not voting_weights_calculated:
             raise InvalidStateError(
                 'Rules coverages must have been calculated before prediction.' +
                 'Did you forget to call update(...) method?'

--- a/decision_rules/core/ruleset.py
+++ b/decision_rules/core/ruleset.py
@@ -50,7 +50,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         """Returns metrics object instance."""
         return None
 
-    def _validate__object_state_before_prediction(self):
+    def _validate_object_state_before_prediction(self):
         voting_weights_calculated: bool = all([
             rule.coverage is not None for rule in self.rules
         ])
@@ -342,7 +342,7 @@ class AbstractRuleSet(_PredictionModel, ABC):
         """
         X: np.ndarray = self._sanitize_dataset(X)
         coverage_matrix: np.ndarray = self.calculate_coverage_matrix(X)
-        self._validate__object_state_before_prediction()
+        self._validate_object_state_before_prediction()
         return self.predict_using_coverage_matrix(coverage_matrix)
 
     def calculate_rules_metrics(

--- a/decision_rules/serialization/__init__.py
+++ b/decision_rules/serialization/__init__.py
@@ -5,4 +5,5 @@ rules and rulesets.
 import decision_rules.serialization._classification
 import decision_rules.serialization._regression
 import decision_rules.serialization._survival
-from decision_rules.serialization.utils import JSONSerializer
+from decision_rules.serialization.utils import (JSONSerializer,
+                                                SerializationModes)

--- a/decision_rules/serialization/_classification/rule.py
+++ b/decision_rules/serialization/_classification/rule.py
@@ -1,18 +1,23 @@
 """
 Contains classes for classification rule's JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Any
 
 from pydantic import BaseModel
 
-from decision_rules.classification.rule import (ClassificationConclusion,
-                                                ClassificationRule)
+from decision_rules.classification.rule import (
+    ClassificationConclusion,
+    ClassificationRule,
+)
 from decision_rules.serialization._core.rule import _BaseRuleSerializer
-from decision_rules.serialization.utils import (JSONClassSerializer,
-                                                SerializationModes,
-                                                register_serializer)
+from decision_rules.serialization.utils import (
+    JSONClassSerializer,
+    SerializationModes,
+    register_serializer,
+)
 
 
 @register_serializer(ClassificationConclusion)
@@ -23,16 +28,13 @@ class _ClassificationRuleConclusionSerializer(JSONClassSerializer):
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> ClassificationConclusion:
-        return ClassificationConclusion(
-            value=model.value,
-            column_name=None
-        )
+        return ClassificationConclusion(value=model.value, column_name=None)
 
     @classmethod
     def _to_pydantic_model(
         cls: type,
         instance: ClassificationConclusion,
-        mode: SerializationModes # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _Model:
         return _ClassificationRuleConclusionSerializer._Model(
             value=instance.value,

--- a/decision_rules/serialization/_classification/rule.py
+++ b/decision_rules/serialization/_classification/rule.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from decision_rules.classification.rule import ClassificationConclusion
-from decision_rules.classification.rule import ClassificationRule
-from decision_rules.serialization._core.rule import _BaseRuleSerializer
-from decision_rules.serialization.utils import JSONClassSerializer
-from decision_rules.serialization.utils import register_serializer
 from pydantic import BaseModel
+
+from decision_rules.classification.rule import (ClassificationConclusion,
+                                                ClassificationRule)
+from decision_rules.serialization._core.rule import _BaseRuleSerializer
+from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                SerializationModes,
+                                                register_serializer)
 
 
 @register_serializer(ClassificationConclusion)
@@ -29,7 +31,8 @@ class _ClassificationRuleConclusionSerializer(JSONClassSerializer):
     @classmethod
     def _to_pydantic_model(
         cls: type,
-        instance: ClassificationConclusion
+        instance: ClassificationConclusion,
+        mode: SerializationModes # pylint: disable=unused-argument
     ) -> _Model:
         return _ClassificationRuleConclusionSerializer._Model(
             value=instance.value,

--- a/decision_rules/serialization/_classification/ruleset.py
+++ b/decision_rules/serialization/_classification/ruleset.py
@@ -1,6 +1,7 @@
 """
 Contains classes for classification ruleset JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -37,12 +38,9 @@ class _ClassificationRuleSetSerializer(JSONClassSerializer):
     def _from_pydantic_model(cls: type, model: _Model) -> ClassificationRuleSet:
         ruleset = ClassificationRuleSet(  # pylint: disable=abstract-class-instantiated
             rules=[
-                JSONSerializer.deserialize(
-                    rule,
-                    ClassificationRule
-                ) for rule in model.rules
+                JSONSerializer.deserialize(rule, ClassificationRule)
+                for rule in model.rules
             ],
-
         )
         ruleset.y_values = np.array(
             list(model.meta.decision_attribute_distribution.keys())
@@ -57,12 +55,9 @@ class _ClassificationRuleSetSerializer(JSONClassSerializer):
 
     @classmethod
     def _calculate_P_N(
-        cls: type,
-        model: _Model,
-        ruleset: ClassificationRuleSet
+        cls: type, model: _Model, ruleset: ClassificationRuleSet
     ):  # pylint: disable=invalid-name
-        all_example_count = sum(
-            model.meta.decision_attribute_distribution.values())
+        all_example_count = sum(model.meta.decision_attribute_distribution.values())
         ruleset.train_P = {}
         ruleset.train_N = {}
         for y_value, count in model.meta.decision_attribute_distribution.items():
@@ -79,7 +74,7 @@ class _ClassificationRuleSetSerializer(JSONClassSerializer):
     def _set_default_conclusion(
         cls: type,
         ruleset: ClassificationRuleSet,
-        default_conclusion_serialized: _ClassificationRuleConclusionSerializer
+        default_conclusion_serialized: _ClassificationRuleConclusionSerializer,
     ):
         if default_conclusion_serialized is not None:
             default_conclusion = _ClassificationRuleConclusionSerializer._from_pydantic_model(  # pylint: disable=protected-access
@@ -91,12 +86,10 @@ class _ClassificationRuleSetSerializer(JSONClassSerializer):
 
     @classmethod
     def _to_pydantic_model(
-        cls: type,
-        instance: ClassificationRuleSet,
-        mode: SerializationModes
+        cls: type, instance: ClassificationRuleSet, mode: SerializationModes
     ) -> _Model:
         if len(instance.rules) == 0:
-            raise ValueError('Cannot serialize empty ruleset.')
+            raise ValueError("Cannot serialize empty ruleset.")
         if mode == SerializationModes.MINIMAL:
             default_conclusion = None
         else:
@@ -110,8 +103,5 @@ class _ClassificationRuleSetSerializer(JSONClassSerializer):
                 decision_attribute_distribution=dict(instance.train_P.items()),
                 default_conclusion=default_conclusion,
             ),
-            rules=[
-                JSONSerializer.serialize(rule, mode)
-                for rule in instance.rules
-            ]
+            rules=[JSONSerializer.serialize(rule, mode) for rule in instance.rules],
         )

--- a/decision_rules/serialization/_core/conditions.py
+++ b/decision_rules/serialization/_core/conditions.py
@@ -1,6 +1,7 @@
 """
 Contains condition's classes JSON serializers.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -8,13 +9,20 @@ from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 
-from decision_rules.conditions import (AbstractCondition, AttributesCondition,
-                                       CompoundCondition, ElementaryCondition,
-                                       LogicOperators, NominalCondition)
-from decision_rules.serialization.utils import (JSONClassSerializer,
-                                                JSONSerializer,
-                                                SerializationModes,
-                                                register_serializer)
+from decision_rules.conditions import (
+    AbstractCondition,
+    AttributesCondition,
+    CompoundCondition,
+    ElementaryCondition,
+    LogicOperators,
+    NominalCondition,
+)
+from decision_rules.serialization.utils import (
+    JSONClassSerializer,
+    JSONSerializer,
+    SerializationModes,
+    register_serializer,
+)
 
 
 class _BaseConditionModel(BaseModel):
@@ -31,17 +39,18 @@ class _BaseConditionSerializer:  # pylint: disable=too-few-public-methods
 
 class _NominalConditionSerializer(_BaseConditionSerializer, JSONClassSerializer):
 
-    condition_type: str = 'elementary_nominal'
+    condition_type: str = "elementary_nominal"
     condition_class: type = NominalCondition
 
     class _Model(_BaseConditionModel):
         value: str
 
     @staticmethod
-    def _from_pydantic_model(model: _NominalConditionSerializer._Model) -> NominalCondition:
+    def _from_pydantic_model(
+        model: _NominalConditionSerializer._Model,
+    ) -> NominalCondition:
         condition = NominalCondition(
-            column_index=model.attributes[0],
-            value=model.value
+            column_index=model.attributes[0], value=model.value
         )
         condition.negated = model.negated if model.negated is not None else False
         return condition
@@ -49,7 +58,7 @@ class _NominalConditionSerializer(_BaseConditionSerializer, JSONClassSerializer)
     @staticmethod
     def _to_pydantic_model(
         instance: NominalCondition,
-        mode: SerializationModes  # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _NominalConditionSerializer._Model:
         return _NominalConditionSerializer._Model(
             type=_NominalConditionSerializer.condition_type,
@@ -61,7 +70,7 @@ class _NominalConditionSerializer(_BaseConditionSerializer, JSONClassSerializer)
 
 class _ElementaryConditionSerializer(_BaseConditionSerializer, JSONClassSerializer):
 
-    condition_type: str = 'elementary_numerical'
+    condition_type: str = "elementary_numerical"
     condition_class: type = ElementaryCondition
 
     class _Model(_BaseConditionModel):
@@ -71,15 +80,17 @@ class _ElementaryConditionSerializer(_BaseConditionSerializer, JSONClassSerializ
         right_closed: bool
 
     @staticmethod
-    def _from_pydantic_model(model: _ElementaryConditionSerializer._Model) -> ElementaryCondition:
-        left = model.left if model.left is not None else float('-inf')
-        right = model.right if model.right is not None else float('inf')
+    def _from_pydantic_model(
+        model: _ElementaryConditionSerializer._Model,
+    ) -> ElementaryCondition:
+        left = model.left if model.left is not None else float("-inf")
+        right = model.right if model.right is not None else float("inf")
         condition = ElementaryCondition(
             column_index=model.attributes[0],
             left=left,
             right=right,
             left_closed=model.left_closed,
-            right_closed=model.right_closed
+            right_closed=model.right_closed,
         )
         condition.negated = model.negated if model.negated is not None else False
         return condition
@@ -87,10 +98,10 @@ class _ElementaryConditionSerializer(_BaseConditionSerializer, JSONClassSerializ
     @staticmethod
     def _to_pydantic_model(
         instance: ElementaryCondition,
-        mode: SerializationModes  # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _ElementaryConditionSerializer._Model:
-        left = instance.left if instance.left != float('-inf') else None
-        right = instance.right if instance.right != float('inf') else None
+        left = instance.left if instance.left != float("-inf") else None
+        right = instance.right if instance.right != float("inf") else None
         return _ElementaryConditionSerializer._Model(
             type=_ElementaryConditionSerializer.condition_type,
             attributes=[instance.column_index],
@@ -98,24 +109,26 @@ class _ElementaryConditionSerializer(_BaseConditionSerializer, JSONClassSerializ
             left=left,
             right=right,
             left_closed=instance.left_closed,
-            right_closed=instance.right_closed
+            right_closed=instance.right_closed,
         )
 
 
 class _AttributesConditionSerializer(_BaseConditionSerializer, JSONClassSerializer):
 
-    condition_type: str = 'attributes'
+    condition_type: str = "attributes"
     condition_class: type = AttributesCondition
 
     class _Model(_BaseConditionModel):
         operator: str
 
     @staticmethod
-    def _from_pydantic_model(model: _AttributesConditionSerializer._Model) -> AttributesCondition:
+    def _from_pydantic_model(
+        model: _AttributesConditionSerializer._Model,
+    ) -> AttributesCondition:
         condition = AttributesCondition(
             operator=model.operator,
             column_left=model.attributes[0],
-            column_right=model.attributes[1]
+            column_right=model.attributes[1],
         )
         condition.negated = model.negated if model.negated is not None else False
         return condition
@@ -123,19 +136,19 @@ class _AttributesConditionSerializer(_BaseConditionSerializer, JSONClassSerializ
     @staticmethod
     def _to_pydantic_model(
         instance: AttributesCondition,
-        mode: SerializationModes  # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _AttributesConditionSerializer._Model:
         return _AttributesConditionSerializer._Model(
             type=_AttributesConditionSerializer.condition_type,
             attributes=[instance.column_left, instance.column_right],
             negated=instance.negated,
-            operator=instance.operator
+            operator=instance.operator,
         )
 
 
 class _CompoundConditionSerializer(_BaseConditionSerializer, JSONClassSerializer):
 
-    condition_type: str = 'compound'
+    condition_type: str = "compound"
     condition_class: type = CompoundCondition
 
     class _Model(_BaseConditionModel):
@@ -144,14 +157,17 @@ class _CompoundConditionSerializer(_BaseConditionSerializer, JSONClassSerializer
         attributes: Optional[list[int]] = []
 
     @staticmethod
-    def _from_pydantic_model(model: _CompoundConditionSerializer._Model) -> CompoundCondition:
+    def _from_pydantic_model(
+        model: _CompoundConditionSerializer._Model,
+    ) -> CompoundCondition:
         condition = CompoundCondition(
             subconditions=[
                 _ConditionSerializer.deserialize(
                     subcondition,
-                ) for subcondition in model.subconditions
+                )
+                for subcondition in model.subconditions
             ],
-            logic_operator=model.operator
+            logic_operator=model.operator,
         )
         condition.negated = model.negated if model.negated is not None else False
         condition.logic_operator = LogicOperators[condition.logic_operator]
@@ -159,8 +175,7 @@ class _CompoundConditionSerializer(_BaseConditionSerializer, JSONClassSerializer
 
     @staticmethod
     def _to_pydantic_model(
-        instance: CompoundCondition,
-        mode: SerializationModes
+        instance: CompoundCondition, mode: SerializationModes
     ) -> _CompoundConditionSerializer._Model:
         subconditions: list[dict] = []
         attributes = set()
@@ -172,7 +187,7 @@ class _CompoundConditionSerializer(_BaseConditionSerializer, JSONClassSerializer
             negated=instance.negated,
             operator=instance.logic_operator.value,
             attributes=list(attributes),
-            subconditions=subconditions
+            subconditions=subconditions,
         )
 
 
@@ -186,27 +201,26 @@ class _ConditionSerializer(JSONClassSerializer):
         _NominalConditionSerializer,
         _ElementaryConditionSerializer,
         _AttributesConditionSerializer,
-        _CompoundConditionSerializer
+        _CompoundConditionSerializer,
     ]
 
     _conditions_types_map: dict[type, JSONClassSerializer] = {
-        s.condition_type: s
-        for s in _elementary_conditions_serializers
+        s.condition_type: s for s in _elementary_conditions_serializers
     }
     _conditions_serializers_map: dict[str, JSONClassSerializer] = {
-        s.condition_class: s
-        for s in _elementary_conditions_serializers
+        s.condition_class: s for s in _elementary_conditions_serializers
     }
 
     @classmethod
     def serialize(
         cls,
         instance: AbstractCondition,
-        mode: Union[str, SerializationModes] = SerializationModes.FULL
+        mode: Union[str, SerializationModes] = SerializationModes.FULL,
     ) -> dict:
-        return cls._conditions_serializers_map[instance.__class__] \
-            .serialize(instance, SerializationModes.instantiate(mode))
+        return cls._conditions_serializers_map[instance.__class__].serialize(
+            instance, SerializationModes.instantiate(mode)
+        )
 
     @classmethod
     def deserialize(cls, data: Union[dict, BaseModel]) -> Any:
-        return cls._conditions_types_map[data['type']].deserialize(data)
+        return cls._conditions_types_map[data["type"]].deserialize(data)

--- a/decision_rules/serialization/_core/rule.py
+++ b/decision_rules/serialization/_core/rule.py
@@ -1,6 +1,7 @@
 """
 Contains common classes for rules JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -10,10 +11,12 @@ from pydantic import BaseModel
 from decision_rules.core.coverage import Coverage
 from decision_rules.core.rule import AbstractRule
 from decision_rules.serialization._core.conditions import _ConditionSerializer
-from decision_rules.serialization.utils import (JSONClassSerializer,
-                                                JSONSerializer,
-                                                SerializationModes,
-                                                register_serializer)
+from decision_rules.serialization.utils import (
+    JSONClassSerializer,
+    JSONSerializer,
+    SerializationModes,
+    register_serializer,
+)
 
 
 @register_serializer(Coverage)
@@ -31,14 +34,14 @@ class _CoverageSerializer(JSONClassSerializer):
             p=int(model.p),
             n=int(model.n),
             P=int(model.P) if model.P is not None else None,
-            N=int(model.N) if model.N is not None else None
+            N=int(model.N) if model.N is not None else None,
         )
 
     @classmethod
     def _to_pydantic_model(
         cls: type,
         instance: Coverage,
-        mode: SerializationModes # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _Model:
         return _CoverageSerializer._Model(
             p=int(instance.p) if instance.p is not None else None,
@@ -64,19 +67,14 @@ class _BaseRuleSerializer(JSONClassSerializer):
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> AbstractRule:
         rule: AbstractRule = cls.rule_class(
-            premise=_ConditionSerializer.deserialize(
-                model.premise),
+            premise=_ConditionSerializer.deserialize(model.premise),
             conclusion=JSONSerializer.deserialize(
-                model.conclusion,
-                cls.conclusion_class
+                model.conclusion, cls.conclusion_class
             ),
             column_names=[],  # must be populated when deserializing ruleset!
         )
         rule._uuid = model.uuid  # pylint: disable=protected-access
-        rule.coverage = JSONSerializer.deserialize(
-            model.coverage,
-            Coverage
-        )
+        rule.coverage = JSONSerializer.deserialize(model.coverage, Coverage)
         if model.voting_weight is not None:
             rule.voting_weight = model.voting_weight
         return rule
@@ -85,7 +83,7 @@ class _BaseRuleSerializer(JSONClassSerializer):
     def _to_pydantic_model(
         cls: type,
         instance: AbstractRule,
-        mode: SerializationModes  # pylint: disable=unused-argument
+        mode: SerializationModes,  # pylint: disable=unused-argument
     ) -> _Model:
         if mode == SerializationModes.FULL:
             coverage: Coverage = instance.coverage
@@ -99,7 +97,8 @@ class _BaseRuleSerializer(JSONClassSerializer):
                 show_coverage=False
             ),
             premise=JSONSerializer.serialize(
-                instance.premise, mode),  # pylint: disable=duplicate-code
+                instance.premise, mode
+            ),  # pylint: disable=duplicate-code
             conclusion=JSONSerializer.serialize(instance.conclusion, mode),
             coverage=JSONSerializer.serialize(coverage, mode),
             voting_weight=voting_weight,

--- a/decision_rules/serialization/_core/rule.py
+++ b/decision_rules/serialization/_core/rule.py
@@ -3,16 +3,16 @@ Contains common classes for rules JSON serialization.
 """
 from __future__ import annotations
 
-from typing import Any
-from typing import Optional
+from typing import Any, Optional
+
+from pydantic import BaseModel
 
 from decision_rules.core.coverage import Coverage
 from decision_rules.core.rule import AbstractRule
 from decision_rules.serialization._core.conditions import _ConditionSerializer
-from decision_rules.serialization.utils import JSONClassSerializer
-from decision_rules.serialization.utils import JSONSerializer
-from decision_rules.serialization.utils import register_serializer
-from pydantic import BaseModel
+from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                JSONSerializer,
+                                                register_serializer)
 
 
 @register_serializer(Coverage)
@@ -57,10 +57,11 @@ class _BaseRuleSerializer(JSONClassSerializer):
         premise: Any
         conclusion: Any
         coverage: Optional[_CoverageSerializer._Model] = None
+        voting_weight: Optional[float] = None
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> AbstractRule:
-        rule = cls.rule_class(
+        rule: AbstractRule = cls.rule_class(
             premise=_ConditionSerializer.deserialize(
                 model.premise),
             conclusion=JSONSerializer.deserialize(
@@ -75,6 +76,8 @@ class _BaseRuleSerializer(JSONClassSerializer):
                 model.coverage,
                 Coverage
             )
+        if model.voting_weight is not None:
+            rule.voting_weight = model.voting_weight
         return rule
 
     @classmethod
@@ -87,6 +90,7 @@ class _BaseRuleSerializer(JSONClassSerializer):
             premise=JSONSerializer.serialize(
                 instance.premise),  # pylint: disable=duplicate-code
             conclusion=JSONSerializer.serialize(instance.conclusion),
-            coverage=JSONSerializer.serialize(instance.coverage)
+            coverage=JSONSerializer.serialize(instance.coverage),
+            voting_weight=instance.voting_weight,
         )
         return model

--- a/decision_rules/serialization/_regression/rule.py
+++ b/decision_rules/serialization/_regression/rule.py
@@ -1,6 +1,7 @@
 """
 Contains classes for regression rule's JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -9,9 +10,11 @@ from pydantic import BaseModel
 
 from decision_rules.regression.rule import RegressionConclusion, RegressionRule
 from decision_rules.serialization._core.rule import _BaseRuleSerializer
-from decision_rules.serialization.utils import (JSONClassSerializer,
-                                                SerializationModes,
-                                                register_serializer)
+from decision_rules.serialization.utils import (
+    JSONClassSerializer,
+    SerializationModes,
+    register_serializer,
+)
 
 
 @register_serializer(RegressionConclusion)
@@ -34,7 +37,7 @@ class _RegressionRuleConclusionSerializer(JSONClassSerializer):
             column_name=None,
             low=model.low,
             high=model.high,
-            fixed=model.fixed
+            fixed=model.fixed,
         )
         conclusion.train_covered_y_mean = model.train_covered_y_mean
         conclusion.train_covered_y_std = model.train_covered_y_std
@@ -44,9 +47,7 @@ class _RegressionRuleConclusionSerializer(JSONClassSerializer):
 
     @classmethod
     def _to_pydantic_model(
-        cls: type,
-        instance: RegressionConclusion,
-        mode: SerializationModes
+        cls: type, instance: RegressionConclusion, mode: SerializationModes
     ) -> _Model:
         if mode == SerializationModes.FULL:
             train_covered_y_mean = instance.train_covered_y_mean
@@ -54,8 +55,9 @@ class _RegressionRuleConclusionSerializer(JSONClassSerializer):
             train_covered_y_min = instance.train_covered_y_min
             train_covered_y_max = instance.train_covered_y_max
         else:
-            train_covered_y_mean = train_covered_y_std = train_covered_y_min = \
-                train_covered_y_max = None
+            train_covered_y_mean = train_covered_y_std = train_covered_y_min = (
+                train_covered_y_max
+            ) = None
         return _RegressionRuleConclusionSerializer._Model(
             value=instance.value,
             low=instance.low,

--- a/decision_rules/serialization/_regression/rule.py
+++ b/decision_rules/serialization/_regression/rule.py
@@ -3,15 +3,15 @@ Contains classes for regression rule's JSON serialization.
 """
 from __future__ import annotations
 
-from typing import Any
-from typing import Optional
+from typing import Any, Optional
 
-from decision_rules.regression.rule import RegressionConclusion
-from decision_rules.regression.rule import RegressionRule
-from decision_rules.serialization._core.rule import _BaseRuleSerializer
-from decision_rules.serialization.utils import JSONClassSerializer
-from decision_rules.serialization.utils import register_serializer
 from pydantic import BaseModel
+
+from decision_rules.regression.rule import RegressionConclusion, RegressionRule
+from decision_rules.serialization._core.rule import _BaseRuleSerializer
+from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                SerializationModes,
+                                                register_serializer)
 
 
 @register_serializer(RegressionConclusion)
@@ -45,17 +45,26 @@ class _RegressionRuleConclusionSerializer(JSONClassSerializer):
     @classmethod
     def _to_pydantic_model(
         cls: type,
-        instance: RegressionConclusion
+        instance: RegressionConclusion,
+        mode: SerializationModes
     ) -> _Model:
+        if mode == SerializationModes.FULL:
+            train_covered_y_mean = instance.train_covered_y_mean
+            train_covered_y_std = instance.train_covered_y_std
+            train_covered_y_min = instance.train_covered_y_min
+            train_covered_y_max = instance.train_covered_y_max
+        else:
+            train_covered_y_mean = train_covered_y_std = train_covered_y_min = \
+                train_covered_y_max = None
         return _RegressionRuleConclusionSerializer._Model(
             value=instance.value,
             low=instance.low,
             high=instance.high,
             fixed=instance.fixed,
-            train_covered_y_mean=instance.train_covered_y_mean,
-            train_covered_y_std=instance.train_covered_y_std,
-            train_covered_y_min=instance.train_covered_y_min,
-            train_covered_y_max=instance.train_covered_y_max,
+            train_covered_y_mean=train_covered_y_mean,
+            train_covered_y_std=train_covered_y_std,
+            train_covered_y_min=train_covered_y_min,
+            train_covered_y_max=train_covered_y_max,
         )
 
 

--- a/decision_rules/serialization/_regression/ruleset.py
+++ b/decision_rules/serialization/_regression/ruleset.py
@@ -1,6 +1,7 @@
 """
 Contains classes for regression ruleset JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Optional
@@ -36,12 +37,8 @@ class _RegressionRuleSetSerializer(JSONClassSerializer):
     def _from_pydantic_model(cls: type, model: _Model) -> RegressionRuleSet:
         ruleset = RegressionRuleSet(  # pylint: disable=abstract-class-instantiated
             rules=[
-                JSONSerializer.deserialize(
-                    rule,
-                    RegressionRule
-                ) for rule in model.rules
+                JSONSerializer.deserialize(rule, RegressionRule) for rule in model.rules
             ],
-
         )
         ruleset.column_names = model.meta.attributes
         ruleset.decision_attribute = model.meta.decision_attribute
@@ -51,26 +48,19 @@ class _RegressionRuleSetSerializer(JSONClassSerializer):
             rule.conclusion.column_name = model.meta.decision_attribute
             rule.train_covered_y_mean = rule.conclusion.train_covered_y_mean
             if model.rules[i].coverage is not None:
-                rule.coverage = Coverage(
-                    **model.rules[i].coverage.model_dump()
-                )
-        ruleset._y_train_median = model.meta.y_train_median  # pylint: disable=protected-access
+                rule.coverage = Coverage(**model.rules[i].coverage.model_dump())
+        ruleset._y_train_median = (
+            model.meta.y_train_median
+        )  # pylint: disable=protected-access
 
-        _RegressionRuleSetSerializer._set_default_conclusion(
-            ruleset, model
-        )
+        _RegressionRuleSetSerializer._set_default_conclusion(ruleset, model)
         return ruleset
 
     @classmethod
-    def _set_default_conclusion(
-        cls: type,
-        ruleset: RegressionRuleSet,
-        model: _Model
-    ):
+    def _set_default_conclusion(cls: type, ruleset: RegressionRuleSet, model: _Model):
         if model.meta.default_conclusion is not None:
             default_conclusion: RegressionConclusion = JSONSerializer.deserialize(
-                model.meta.default_conclusion,
-                target_class=RegressionConclusion
+                model.meta.default_conclusion, target_class=RegressionConclusion
             )
             ruleset.default_conclusion = default_conclusion
         else:
@@ -83,12 +73,10 @@ class _RegressionRuleSetSerializer(JSONClassSerializer):
 
     @classmethod
     def _to_pydantic_model(
-        cls: type,
-        instance: RegressionRuleSet,
-        mode: SerializationModes
+        cls: type, instance: RegressionRuleSet, mode: SerializationModes
     ) -> _Model:
         if len(instance.rules) == 0:
-            raise ValueError('Cannot serialize empty ruleset.')
+            raise ValueError("Cannot serialize empty ruleset.")
         if mode == SerializationModes.FULL:
             default_conclusion = JSONSerializer.serialize(
                 instance.default_conclusion, mode
@@ -102,8 +90,5 @@ class _RegressionRuleSetSerializer(JSONClassSerializer):
                 y_train_median=instance.y_train_median,
                 default_conclusion=default_conclusion,
             ),
-            rules=[
-                JSONSerializer.serialize(rule, mode)
-                for rule in instance.rules
-            ]
+            rules=[JSONSerializer.serialize(rule, mode) for rule in instance.rules],
         )

--- a/decision_rules/serialization/_survival/kaplan_meier.py
+++ b/decision_rules/serialization/_survival/kaplan_meier.py
@@ -1,6 +1,7 @@
 """
 Contains classes for Kaplan-Meier JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Optional, Union
@@ -22,7 +23,9 @@ class _KaplanMeierEstimatorModel(BaseModel):
     value: Optional[float] = None
 
     @staticmethod
-    def from_conclusion(conclusion: SurvivalConclusion) -> Optional[_KaplanMeierEstimatorModel]:
+    def from_conclusion(
+        conclusion: SurvivalConclusion,
+    ) -> Optional[_KaplanMeierEstimatorModel]:
         """Build pydantic model from SurvivalConclusion
 
         Args:
@@ -34,8 +37,7 @@ class _KaplanMeierEstimatorModel(BaseModel):
         """
         return (
             _KaplanMeierEstimatorModel(
-                **conclusion.estimator.get_dict(),
-                value=conclusion.value
+                **conclusion.estimator.get_dict(), value=conclusion.value
             )
             if conclusion.estimator is not None
             else None
@@ -49,7 +51,7 @@ class _KaplanMeierEstimatorModel(BaseModel):
         """
         return KaplanMeierEstimator().update(
             self._to_kaplan_meier_estimator_dict(),
-            update_additional_indicators=len(self.times) > 0
+            update_additional_indicators=len(self.times) > 0,
         )
 
     def _to_kaplan_meier_estimator_dict(self) -> KaplanMeierEstimatorDict:

--- a/decision_rules/serialization/_survival/kaplan_meier.py
+++ b/decision_rules/serialization/_survival/kaplan_meier.py
@@ -1,0 +1,58 @@
+"""
+Contains classes for Kaplan-Meier JSON serialization.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pydantic import BaseModel
+
+from decision_rules.survival.kaplan_meier import (KaplanMeierEstimator,
+                                                  KaplanMeierEstimatorDict)
+from decision_rules.survival.rule import SurvivalConclusion
+
+
+class _KaplanMeierEstimatorModel(BaseModel):
+    times: list[Union[int, float]]
+    events_count: list[int]
+    censored_count: list[int]
+    at_risk_count: list[int]
+    probabilities: list[float]
+
+    value: Optional[float]
+
+    @staticmethod
+    def from_rule_conclusion(conclusion: SurvivalConclusion) -> Optional[_KaplanMeierEstimatorModel]:
+        """Build pydantic model from SurvivalConclusion
+
+        Args:
+            conclusion (SurvivalConclusion): conclusion
+
+        Returns:
+            Optional[_KaplanMeierEstimatorModel]: pydantic model or None if
+            estimator of the conclusion is None
+        """
+        return (
+            _KaplanMeierEstimatorModel(
+                **conclusion.estimator.get_dict(),
+                value=conclusion.value
+            )
+            if conclusion.estimator is not None
+            else None
+        )
+
+    def to_estimator_object(self) -> KaplanMeierEstimator:
+        """Convert pydantic model to KaplanMeierEstimator object
+
+        Returns:
+            KaplanMeierEstimator: estimator object
+        """
+        return KaplanMeierEstimator().update(
+            self._to_kaplan_meier_estimator_dict(),
+            update_additional_indicators=True
+        )
+
+    def _to_kaplan_meier_estimator_dict(self) -> KaplanMeierEstimatorDict:
+        value: dict = self.model_dump()
+        del value["value"]
+        return value

--- a/decision_rules/serialization/_survival/kaplan_meier.py
+++ b/decision_rules/serialization/_survival/kaplan_meier.py
@@ -19,10 +19,10 @@ class _KaplanMeierEstimatorModel(BaseModel):
     at_risk_count: list[int]
     probabilities: list[float]
 
-    value: Optional[float]
+    value: Optional[float] = None
 
     @staticmethod
-    def from_rule_conclusion(conclusion: SurvivalConclusion) -> Optional[_KaplanMeierEstimatorModel]:
+    def from_conclusion(conclusion: SurvivalConclusion) -> Optional[_KaplanMeierEstimatorModel]:
         """Build pydantic model from SurvivalConclusion
 
         Args:
@@ -49,7 +49,7 @@ class _KaplanMeierEstimatorModel(BaseModel):
         """
         return KaplanMeierEstimator().update(
             self._to_kaplan_meier_estimator_dict(),
-            update_additional_indicators=True
+            update_additional_indicators=len(self.times) > 0
         )
 
     def _to_kaplan_meier_estimator_dict(self) -> KaplanMeierEstimatorDict:

--- a/decision_rules/serialization/_survival/rule.py
+++ b/decision_rules/serialization/_survival/rule.py
@@ -3,14 +3,16 @@ Contains classes for survival rule's JSON serialization.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
+
+from pydantic import BaseModel
 
 from decision_rules.serialization._core.rule import _BaseRuleSerializer
-from decision_rules.serialization.utils import JSONClassSerializer
-from decision_rules.serialization.utils import register_serializer
-from decision_rules.survival.rule import SurvivalConclusion
-from decision_rules.survival.rule import SurvivalRule
-from pydantic import BaseModel
+from decision_rules.serialization._survival.kaplan_meier import \
+    _KaplanMeierEstimatorModel
+from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                register_serializer)
+from decision_rules.survival.rule import SurvivalConclusion, SurvivalRule
 
 
 @register_serializer(SurvivalConclusion)
@@ -20,6 +22,7 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
         value: Any
         median_survival_time_ci_lower: Any
         median_survival_time_ci_upper: Any
+        estimator: Optional[_KaplanMeierEstimatorModel]
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> SurvivalConclusion:
@@ -29,6 +32,9 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
         )
         conclusion.median_survival_time_ci_lower = model.median_survival_time_ci_lower
         conclusion.median_survival_time_ci_upper = model.median_survival_time_ci_upper
+        if model.estimator is not None:
+            conclusion.estimator = model.estimator.to_estimator_object()
+            conclusion.value = model.estimator.value
         return conclusion
 
     @classmethod
@@ -41,6 +47,9 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
             median_survival_time_ci_lower=instance.median_survival_time_ci_lower,
             median_survival_time_ci_upper=instance.median_survival_time_ci_upper,
             column_name=instance.column_name,
+            estimator=_KaplanMeierEstimatorModel.from_rule_conclusion(
+                instance
+            )
         )
 
 

--- a/decision_rules/serialization/_survival/rule.py
+++ b/decision_rules/serialization/_survival/rule.py
@@ -11,7 +11,9 @@ from decision_rules.serialization._core.rule import _BaseRuleSerializer
 from decision_rules.serialization._survival.kaplan_meier import \
     _KaplanMeierEstimatorModel
 from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                SerializationModes,
                                                 register_serializer)
+from decision_rules.survival.kaplan_meier import KaplanMeierEstimator
 from decision_rules.survival.rule import SurvivalConclusion, SurvivalRule
 
 
@@ -22,7 +24,7 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
         value: Any
         median_survival_time_ci_lower: Any
         median_survival_time_ci_upper: Any
-        estimator: Optional[_KaplanMeierEstimatorModel]
+        estimator: Optional[_KaplanMeierEstimatorModel] = None
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> SurvivalConclusion:
@@ -40,16 +42,21 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
     @classmethod
     def _to_pydantic_model(
         cls: type,
-        instance: SurvivalConclusion
+        instance: SurvivalConclusion,
+        mode: SerializationModes
     ) -> _Model:
+        if mode == SerializationModes.FULL:
+            estimator: KaplanMeierEstimator = _KaplanMeierEstimatorModel.from_conclusion(
+                instance
+            )
+        else:
+            estimator = None
         return _SurvivalRuleConclusionSerializer._Model(
             value=instance.value,
             median_survival_time_ci_lower=instance.median_survival_time_ci_lower,
             median_survival_time_ci_upper=instance.median_survival_time_ci_upper,
             column_name=instance.column_name,
-            estimator=_KaplanMeierEstimatorModel.from_rule_conclusion(
-                instance
-            )
+            estimator=estimator
         )
 
 

--- a/decision_rules/serialization/_survival/rule.py
+++ b/decision_rules/serialization/_survival/rule.py
@@ -1,6 +1,7 @@
 """
 Contains classes for survival rule's JSON serialization.
 """
+
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -28,10 +29,7 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> SurvivalConclusion:
-        conclusion = SurvivalConclusion(
-            value=model.value,
-            column_name=None
-        )
+        conclusion = SurvivalConclusion(value=model.value, column_name=None)
         conclusion.median_survival_time_ci_lower = model.median_survival_time_ci_lower
         conclusion.median_survival_time_ci_upper = model.median_survival_time_ci_upper
         if model.estimator is not None:
@@ -41,13 +39,11 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
 
     @classmethod
     def _to_pydantic_model(
-        cls: type,
-        instance: SurvivalConclusion,
-        mode: SerializationModes
+        cls: type, instance: SurvivalConclusion, mode: SerializationModes
     ) -> _Model:
         if mode == SerializationModes.FULL:
-            estimator: KaplanMeierEstimator = _KaplanMeierEstimatorModel.from_conclusion(
-                instance
+            estimator: KaplanMeierEstimator = (
+                _KaplanMeierEstimatorModel.from_conclusion(instance)
             )
         else:
             estimator = None
@@ -56,7 +52,7 @@ class _SurvivalRuleConclusionSerializer(JSONClassSerializer):
             median_survival_time_ci_lower=instance.median_survival_time_ci_lower,
             median_survival_time_ci_upper=instance.median_survival_time_ci_upper,
             column_name=instance.column_name,
-            estimator=estimator
+            estimator=estimator,
         )
 
 

--- a/decision_rules/serialization/_survival/ruleset.py
+++ b/decision_rules/serialization/_survival/ruleset.py
@@ -5,22 +5,25 @@ from __future__ import annotations
 
 from typing import Optional
 
+from pydantic import BaseModel
+
 from decision_rules.core.coverage import Coverage
+from decision_rules.serialization._survival.kaplan_meier import \
+    _KaplanMeierEstimatorModel
 from decision_rules.serialization._survival.rule import _SurvivalRuleSerializer
-from decision_rules.serialization.utils import JSONClassSerializer
-from decision_rules.serialization.utils import JSONSerializer
-from decision_rules.serialization.utils import register_serializer
+from decision_rules.serialization.utils import (JSONClassSerializer,
+                                                JSONSerializer,
+                                                register_serializer)
 from decision_rules.survival.kaplan_meier import KaplanMeierEstimator
 from decision_rules.survival.rule import SurvivalRule
 from decision_rules.survival.ruleset import SurvivalRuleSet
-from pydantic import BaseModel
 
 
 class _SurvivalMetaDataModel(BaseModel):
     attributes: list[str]
     decision_attribute: str
     survival_time_attribute: str
-    default_conclusion: dict[str, list[float]]
+    default_conclusion: _KaplanMeierEstimatorModel
 
 
 @register_serializer(SurvivalRuleSet)
@@ -32,7 +35,7 @@ class _SurvivalRuleSetSerializer(JSONClassSerializer):
 
     @classmethod
     def _from_pydantic_model(cls: type, model: _Model) -> SurvivalRuleSet:
-        ruleset = SurvivalRuleSet(
+        ruleset = SurvivalRuleSet(  # pylint: disable=abstract-class-instantiated
             rules=[
                 JSONSerializer.deserialize(
                     rule,
@@ -43,12 +46,11 @@ class _SurvivalRuleSetSerializer(JSONClassSerializer):
         )
         ruleset.column_names = model.meta.attributes
         ruleset.decision_attribute = model.meta.decision_attribute
-        ruleset.default_conclusion.estimator = KaplanMeierEstimator().update(
-            model.meta.default_conclusion, update_additional_indicators=True)
+        _SurvivalRuleSetSerializer._update_default_conclusion(
+            ruleset, model
+        )
         for i, rule in enumerate(ruleset.rules):
             rule.column_names = ruleset.column_names
-            if rule.coverage is None:
-                rule.coverage = Coverage(None, None, None, None)
             rule.set_survival_time_attr(model.meta.survival_time_attribute)
             rule.conclusion.column_name = model.meta.decision_attribute
             rule.conclusion.value = rule.conclusion.value
@@ -56,19 +58,43 @@ class _SurvivalRuleSetSerializer(JSONClassSerializer):
             rule.conclusion.median_survival_time_ci_upper = rule.conclusion.median_survival_time_ci_upper,
             if model.rules[i].coverage is not None:
                 rule.coverage = Coverage(
-                    **model.rules[i].coverage.model_dump())
+                    **model.rules[i].coverage.model_dump()
+                )
+            else:
+                rule.coverage = Coverage(None, None, None, None)
         return ruleset
+
+    @classmethod
+    def _update_default_conclusion(
+        cls: type,
+        ruleset: SurvivalRuleSet,
+        model: _Model
+    ):
+        estimator: KaplanMeierEstimator = model.meta.default_conclusion. \
+            to_estimator_object()
+        ruleset.default_conclusion.estimator = estimator
+        ruleset.default_conclusion.value = (
+            estimator.median_survival_time
+            if model.meta.default_conclusion.value is None
+            else model.meta.default_conclusion.value
+        )
 
     @classmethod
     def _to_pydantic_model(cls: type, instance: SurvivalRuleSet) -> _Model:
         if len(instance.rules) == 0:
             raise ValueError('Cannot serialize empty ruleset.')
+        if instance.default_conclusion is None:
+            default_conclusion = None
+        else:
+            default_conclusion = _KaplanMeierEstimatorModel.from_rule_conclusion(
+                instance.default_conclusion
+            )
         return _SurvivalRuleSetSerializer._Model(
             meta=_SurvivalMetaDataModel(
                 attributes=instance.column_names,
                 decision_attribute=instance.rules[0].conclusion.column_name,
                 survival_time_attribute=instance.rules[0].survival_time_attr,
-                default_conclusion=instance.default_conclusion.estimator.get_dict()
+                default_conclusion=default_conclusion
             ),
             rules=[
                 JSONSerializer.serialize(rule) for rule in instance.rules

--- a/decision_rules/serialization/utils.py
+++ b/decision_rules/serialization/utils.py
@@ -3,12 +3,49 @@ Contains classed useful for serializing and deserializing objects.
 """
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
-from typing import Any
-from typing import Union
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Type, Union
 
 from pydantic import BaseModel
+
+
+class SerializationModes(Enum):
+    """
+    Specifies possible serialization modes choice.
+    """
+    FULL: str = 'full'
+    """In this mode all important information is serialized. After 
+    deserialization of the rulesets you can use it as it is without calling `update` 
+    method.
+    """
+    MINIMAL: str = 'minimal'
+    """In this mode only minimal, necessary information is serialized. After 
+    deserialization of the rulesets you'll have to call `update` method to use it.
+    """
+
+    @classmethod
+    def instantiate(cls, value: Union[SerializationModes, str]) -> SerializationModes:
+        """Creates serialization mode instance from given value
+
+        Args:
+            value (Union[SerializationModes, str]): either serialization mode or its name
+
+        Raises:
+            ValueError: If given value is not a valid serialization mode
+
+        Returns:
+            SerializationModes: serialization mode
+        """
+        if isinstance(value, SerializationModes):
+            return value
+        try:
+            return SerializationModes(value.lower())
+        except ValueError as error:
+            raise ValueError(
+                f'Unknown serialization mode: "{value}", '
+                f'expected one of: {list(cls._value2member_map_.keys())}'
+            ) from error
 
 
 class JSONSerializer:
@@ -35,15 +72,26 @@ class JSONSerializer:
             raise ValueError(
                 'Trying to register multiple serializer classes for type: ' +
                 f'"{serializable_class}"' +
-                f' ({cls._serializers_dict[serializable_class], serializer_class})'
+                f' ({
+                    cls._serializers_dict[serializable_class], serializer_class})'
             )
         cls._serializers_dict[serializable_class] = serializer_class
 
     @classmethod
-    def serialize(cls, value: Any) -> dict:
-        """
+    def serialize(
+        cls,
+        value: Any,
+        mode: Union[str, SerializationModes] = SerializationModes.FULL
+    ) -> dict:
+        """Serializes given object to json dictionary
+
         Args:
             value (Any): value
+            mode (Union[str, SerializationModes], optional): Controls serialization mode. 
+                In minimal mode only minimal information is serialized. After deserialization 
+                of the rulesets you'll have to call update method to use it. In full mode all
+                important information is serialized and after ruleset deserialization and
+                you can use it further without calling update. Defaults to SerializationModes.FULL
 
         Raises:
             ValueError: if no serializer class is registered for passed object type
@@ -51,17 +99,18 @@ class JSONSerializer:
         Returns:
             dict: json dictionary
         """
-        value_class = value.__class__
         if value is None:
             return None
+        value_class = value.__class__
         if value_class not in cls._serializers_dict:
             raise ValueError(
                 f'There is no registered JSONClassSerializer for class: "{value_class}"')
-        return cls._serializers_dict[value_class].serialize(value)
+        return cls._serializers_dict[value_class].serialize(value, mode)
 
     @classmethod
     def deserialize(cls, data: dict, target_class: type) -> Any:
-        """
+        """Deserializes json dictionary to given target class
+
         Args:
             data (dict): json dictionary
             target_class (type): target class
@@ -85,7 +134,7 @@ class JSONClassSerializer(ABC):
     class for JSON representation.
     """
 
-    _Model: type
+    _Model: Type[BaseModel]
 
     @classmethod
     @abstractmethod
@@ -101,26 +150,46 @@ class JSONClassSerializer(ABC):
 
     @classmethod
     @abstractmethod
-    def _to_pydantic_model(cls: type, instance: Any) -> BaseModel:
+    def _to_pydantic_model(
+        cls: type,
+        instance: Any,
+        mode: SerializationModes
+    ) -> BaseModel:
         """Creates pydantic model from object instance
 
         Args:
             instance (Any): object instance
+            mode (SerializationModes): Controls serialization mode. 
+                In minimal mode only minimal information is serialized. In full mode all
+                important information is serialized and object should be ready to use without
+                calling any additional methods.
 
         Returns:
             BaseModel: pydantic model
         """
 
     @classmethod
-    def serialize(cls, instance: Any) -> dict:
+    def serialize(
+        cls,
+        instance: Any,
+        mode: Union[str, SerializationModes] = SerializationModes.FULL
+    ) -> dict:
         """
         Args:
             instance (Any): object instance
+            mode (Union[str, SerializationModes], optional): Controls serialization mode. 
+                In minimal mode only minimal information is serialized. After deserialization 
+                of the rulesets you'll have to call update method to use it. In full mode all
+                important information is serialized and after ruleset deserialization and
+                you can use it further without calling update. Defaults to SerializationModes.FULL
 
         Returns:
             dict: json dictionary
         """
-        return cls._to_pydantic_model(instance).model_dump()
+        return cls._to_pydantic_model(
+            instance, 
+            mode=SerializationModes.instantiate(mode)
+        ).model_dump()
 
     @classmethod
     def deserialize(cls, data: Union[dict, BaseModel]) -> Any:
@@ -142,6 +211,16 @@ def register_serializer(
     registered_type: type
 ):
     """Register decorated class to be used as serializer for given type.
+
+    Example
+    -------
+    .. code-block:: python
+        >>> class MyCustomClass(AbstractRule):
+        >>>     ...
+        >>>
+        >>> @register_serializer(MyCustomClass)
+        >>> class MyCustomRuleClassSerializer(JSONClassSerializer):
+        >>>     ...
 
     Args:
         type (type): type of objects to be serialized

--- a/decision_rules/serialization/utils.py
+++ b/decision_rules/serialization/utils.py
@@ -1,6 +1,7 @@
 """
 Contains classed useful for serializing and deserializing objects.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -14,12 +15,13 @@ class SerializationModes(Enum):
     """
     Specifies possible serialization modes choice.
     """
-    FULL: str = 'full'
+
+    FULL: str = "full"
     """In this mode all important information is serialized. After 
     deserialization of the rulesets you can use it as it is without calling `update` 
     method.
     """
-    MINIMAL: str = 'minimal'
+    MINIMAL: str = "minimal"
     """In this mode only minimal, necessary information is serialized. After 
     deserialization of the rulesets you'll have to call `update` method to use it.
     """
@@ -44,7 +46,7 @@ class SerializationModes(Enum):
         except ValueError as error:
             raise ValueError(
                 f'Unknown serialization mode: "{value}", '
-                f'expected one of: {list(cls._value2member_map_.keys())}'
+                f"expected one of: {list(cls._value2member_map_.keys())}"
             ) from error
 
 
@@ -67,27 +69,26 @@ class JSONSerializer:
         Raises:
             ValueError: when try to register multiple serializers for the same type
         """
-        if (serializable_class in cls._serializers_dict) and \
-                (serializer_class != cls._serializers_dict[serializable_class]):
+        if (serializable_class in cls._serializers_dict) and (
+            serializer_class != cls._serializers_dict[serializable_class]
+        ):
             raise ValueError(
-                'Trying to register multiple serializer classes for type: ' +
-                f'"{serializable_class}"' +
-                f'({cls._serializers_dict[serializable_class], serializer_class})'
+                "Trying to register multiple serializer classes for type: "
+                + f'"{serializable_class}"'
+                + f"({cls._serializers_dict[serializable_class], serializer_class})"
             )
         cls._serializers_dict[serializable_class] = serializer_class
 
     @classmethod
     def serialize(
-        cls,
-        value: Any,
-        mode: Union[str, SerializationModes] = SerializationModes.FULL
+        cls, value: Any, mode: Union[str, SerializationModes] = SerializationModes.FULL
     ) -> dict:
         """Serializes given object to json dictionary
 
         Args:
             value (Any): value
-            mode (Union[str, SerializationModes], optional): Controls serialization mode. 
-                In minimal mode only minimal information is serialized. After deserialization 
+            mode (Union[str, SerializationModes], optional): Controls serialization mode.
+                In minimal mode only minimal information is serialized. After deserialization
                 of the rulesets you'll have to call update method to use it. In full mode all
                 important information is serialized and after ruleset deserialization and
                 you can use it further without calling update. Defaults to SerializationModes.FULL
@@ -103,7 +104,8 @@ class JSONSerializer:
         value_class = value.__class__
         if value_class not in cls._serializers_dict:
             raise ValueError(
-                f'There is no registered JSONClassSerializer for class: "{value_class}"')
+                f'There is no registered JSONClassSerializer for class: "{value_class}"'
+            )
         return cls._serializers_dict[value_class].serialize(value, mode)
 
     @classmethod
@@ -122,7 +124,8 @@ class JSONSerializer:
         """
         if target_class not in cls._serializers_dict:
             raise ValueError(
-                f'There is no registered JSONClassSerializer for class: "{target_class}"')
+                f'There is no registered JSONClassSerializer for class: "{target_class}"'
+            )
         return cls._serializers_dict[target_class].deserialize(data)
 
 
@@ -150,15 +153,13 @@ class JSONClassSerializer(ABC):
     @classmethod
     @abstractmethod
     def _to_pydantic_model(
-        cls: type,
-        instance: Any,
-        mode: SerializationModes
+        cls: type, instance: Any, mode: SerializationModes
     ) -> BaseModel:
         """Creates pydantic model from object instance
 
         Args:
             instance (Any): object instance
-            mode (SerializationModes): Controls serialization mode. 
+            mode (SerializationModes): Controls serialization mode.
                 In minimal mode only minimal information is serialized. In full mode all
                 important information is serialized and object should be ready to use without
                 calling any additional methods.
@@ -171,13 +172,13 @@ class JSONClassSerializer(ABC):
     def serialize(
         cls,
         instance: Any,
-        mode: Union[str, SerializationModes] = SerializationModes.FULL
+        mode: Union[str, SerializationModes] = SerializationModes.FULL,
     ) -> dict:
         """
         Args:
             instance (Any): object instance
-            mode (Union[str, SerializationModes], optional): Controls serialization mode. 
-                In minimal mode only minimal information is serialized. After deserialization 
+            mode (Union[str, SerializationModes], optional): Controls serialization mode.
+                In minimal mode only minimal information is serialized. After deserialization
                 of the rulesets you'll have to call update method to use it. In full mode all
                 important information is serialized and after ruleset deserialization and
                 you can use it further without calling update. Defaults to SerializationModes.FULL
@@ -186,8 +187,7 @@ class JSONClassSerializer(ABC):
             dict: json dictionary
         """
         return cls._to_pydantic_model(
-            instance, 
-            mode=SerializationModes.instantiate(mode)
+            instance, mode=SerializationModes.instantiate(mode)
         ).model_dump()
 
     @classmethod
@@ -202,13 +202,11 @@ class JSONClassSerializer(ABC):
         if data is None:
             return None
         if not issubclass(data.__class__, BaseModel):
-            data = getattr(cls, '_Model')(**data)
+            data = getattr(cls, "_Model")(**data)
         return cls._from_pydantic_model(data)
 
 
-def register_serializer(
-    registered_type: type
-):
+def register_serializer(registered_type: type):
     """Register decorated class to be used as serializer for given type.
 
     Example
@@ -224,7 +222,9 @@ def register_serializer(
     Args:
         type (type): type of objects to be serialized
     """
+
     def wrapper(serializer_class):
         JSONSerializer.register_serializer(registered_type, serializer_class)
         return serializer_class
+
     return wrapper

--- a/decision_rules/serialization/utils.py
+++ b/decision_rules/serialization/utils.py
@@ -72,8 +72,7 @@ class JSONSerializer:
             raise ValueError(
                 'Trying to register multiple serializer classes for type: ' +
                 f'"{serializable_class}"' +
-                f' ({
-                    cls._serializers_dict[serializable_class], serializer_class})'
+                f'({cls._serializers_dict[serializable_class], serializer_class})'
             )
         cls._serializers_dict[serializable_class] = serializer_class
 

--- a/decision_rules/survival/kaplan_meier.py
+++ b/decision_rules/survival/kaplan_meier.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 from bisect import bisect_left
-from typing import Optional
-from typing import TypedDict
-from typing import Union
+from typing import Optional, TypedDict, Union
 
 import numpy as np
 import pandas as pd
-from scipy.stats import chi2
-from scipy.stats import norm
+from scipy.stats import chi2, norm
 
 
 class KaplanMeierEstimatorDict(TypedDict):
@@ -86,7 +83,11 @@ class KaplanMeierEstimator():
         self.events_count_sum = np.sum(surv_info.events_count)
         self.censored_count_sum = np.sum(surv_info.censored_count)
 
-    def update(self, kaplan_meier_estimator_dict: dict[str, list[float]], update_additional_indicators: bool = False) -> KaplanMeierEstimator:
+    def update(
+        self,
+        kaplan_meier_estimator_dict: KaplanMeierEstimatorDict,
+        update_additional_indicators: bool = False
+    ) -> KaplanMeierEstimator:
         kaplan_meier_estimator_dict: KaplanMeierEstimatorDict = {
             k: np.array(v)
             for k, v in kaplan_meier_estimator_dict.items()

--- a/decision_rules/survival/kaplan_meier.py
+++ b/decision_rules/survival/kaplan_meier.py
@@ -33,12 +33,9 @@ class SurvInfo:
         self.sq: np.ndarray = np.zeros(shape=len(time))
 
 
-class KaplanMeierEstimator():
+class KaplanMeierEstimator:
 
-    def __init__(
-        self,
-        surv_info: Optional[SurvInfo] = None
-    ) -> None:
+    def __init__(self, surv_info: Optional[SurvInfo] = None) -> None:
         self.median_survival_time: float = None
         self.median_survival_time_cli: float = None
         self.restricted_mean_survival_time: float = None
@@ -56,7 +53,7 @@ class KaplanMeierEstimator():
                 events_count=np.array([]),
                 censored_count=np.array([]),
                 at_risk_count=np.array([]),
-                probability=np.array([])
+                probability=np.array([]),
             )
         else:
             self._surv_info: SurvInfo = surv_info
@@ -86,11 +83,10 @@ class KaplanMeierEstimator():
     def update(
         self,
         kaplan_meier_estimator_dict: KaplanMeierEstimatorDict,
-        update_additional_indicators: bool = False
+        update_additional_indicators: bool = False,
     ) -> KaplanMeierEstimator:
         kaplan_meier_estimator_dict: KaplanMeierEstimatorDict = {
-            k: np.array(v)
-            for k, v in kaplan_meier_estimator_dict.items()
+            k: np.array(v) for k, v in kaplan_meier_estimator_dict.items()
         }
         self.surv_info = SurvInfo(
             time=kaplan_meier_estimator_dict["times"],
@@ -106,9 +102,16 @@ class KaplanMeierEstimator():
 
     def _update_additional_indicators(self):
         self.interval = self.calculate_interval()
-        self.median_survival_time, self.median_survival_time_cli = self.calcualte_indicators()
+        self.median_survival_time, self.median_survival_time_cli = (
+            self.calcualte_indicators()
+        )
 
-    def fit(self, survival_time: np.ndarray, survival_status:  np.ndarray, skip_sorting: bool = False) -> KaplanMeierEstimator:
+    def fit(
+        self,
+        survival_time: np.ndarray,
+        survival_status: np.ndarray,
+        skip_sorting: bool = False,
+    ) -> KaplanMeierEstimator:
         """Fit Kaplan Meier estimator on given data
 
         Args:
@@ -131,7 +134,7 @@ class KaplanMeierEstimator():
             survival_time = survival_time[sorted_indices]
             survival_status = survival_status[sorted_indices]
 
-        events_ocurences: np.ndarray = survival_status == '1'
+        events_ocurences: np.ndarray = survival_status == "1"
         censored_ocurences = np.logical_not(events_ocurences).astype(int)
         events_ocurences = events_ocurences.astype(int)
 
@@ -141,31 +144,32 @@ class KaplanMeierEstimator():
 
         at_risk_count = survival_time.shape[0]
         grouped_data = {
-            'events_count': {},
-            'censored_count': {},
-            'at_risk_count': {},
+            "events_count": {},
+            "censored_count": {},
+            "at_risk_count": {},
         }
         time_point_prev = survival_time[0]
-        for (time_point, event_count, censored_count) in zip(survival_time, events_counts, censored_counts):
+        for time_point, event_count, censored_count in zip(
+            survival_time, events_counts, censored_counts
+        ):
             if time_point != time_point_prev:
-                grouped_data['at_risk_count'][time_point_prev] = at_risk_count
-                at_risk_count -= grouped_data['events_count'][time_point_prev]
-                at_risk_count -= grouped_data['censored_count'][time_point_prev]
+                grouped_data["at_risk_count"][time_point_prev] = at_risk_count
+                at_risk_count -= grouped_data["events_count"][time_point_prev]
+                at_risk_count -= grouped_data["censored_count"][time_point_prev]
                 time_point_prev = time_point
-            if time_point in grouped_data['events_count']:
-                grouped_data['events_count'][time_point] += event_count
-                grouped_data['censored_count'][time_point] += censored_count
+            if time_point in grouped_data["events_count"]:
+                grouped_data["events_count"][time_point] += event_count
+                grouped_data["censored_count"][time_point] += censored_count
             else:
-                grouped_data['events_count'][time_point] = event_count
-                grouped_data['censored_count'][time_point] = censored_count
+                grouped_data["events_count"][time_point] = event_count
+                grouped_data["censored_count"][time_point] = censored_count
 
-        grouped_data['at_risk_count'][time_point] = at_risk_count
+        grouped_data["at_risk_count"][time_point] = at_risk_count
 
-        unique_times = np.array(list(grouped_data['events_count'].keys()))
-        events_count = np.array(list(grouped_data['events_count'].values()))
-        censored_count = np.array(
-            list(grouped_data['censored_count'].values()))
-        at_risk_count = np.array(list(grouped_data['at_risk_count'].values()))
+        unique_times = np.array(list(grouped_data["events_count"].keys()))
+        events_count = np.array(list(grouped_data["events_count"].values()))
+        censored_count = np.array(list(grouped_data["censored_count"].values()))
+        at_risk_count = np.array(list(grouped_data["at_risk_count"].values()))
 
         surv_info = SurvInfo(
             time=unique_times,
@@ -182,37 +186,40 @@ class KaplanMeierEstimator():
 
     def calculate_probabilities(self, surv_info: SurvInfo) -> SurvInfo:
         surv_info.probability = np.zeros(shape=surv_info.at_risk_count.shape)
-        non_zero_probability_mask = (surv_info.at_risk_count != 0)
+        non_zero_probability_mask = surv_info.at_risk_count != 0
 
         masked_at_risk_count = surv_info.at_risk_count[non_zero_probability_mask]
         events_count = surv_info.events_count[non_zero_probability_mask]
 
         surv_info.probability[non_zero_probability_mask] = (
-            (masked_at_risk_count - events_count) / masked_at_risk_count
-        )
+            masked_at_risk_count - events_count
+        ) / masked_at_risk_count
         surv_info.probability = np.cumprod(surv_info.probability)
         return surv_info
 
     def calculate_interval(self) -> pd.DataFrame:
-        with np.errstate(divide="ignore", invalid='ignore'):
-            tmp = (self.events_counts / (self.at_risk_counts *
-                   (self.at_risk_counts - self.events_counts)))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            tmp = self.events_counts / (
+                self.at_risk_counts * (self.at_risk_counts - self.events_counts)
+            )
         cumulative_sq_ = np.cumsum(np.nan_to_num(tmp, posinf=0, neginf=0))
         return self.calculate_bounds(self.times, self.probabilities, cumulative_sq_)
 
     def calcualte_indicators(self) -> tuple[float, float]:
         survival_function = pd.DataFrame(index=self.times)
         survival_function["KM_estimate"] = self.probabilities
-        median_survival_time = self.calculate_median_survival_time(
-            survival_function)
-        median_survival_time_cli = self.calculate_median_survival_time(
-            self.interval)
+        median_survival_time = self.calculate_median_survival_time(survival_function)
+        median_survival_time_cli = self.calculate_median_survival_time(self.interval)
         return median_survival_time, median_survival_time_cli
 
-    def calculate_median_survival_time(self, survival_function: pd.DataFrame) -> Union[float, pd.DataFrame]:
+    def calculate_median_survival_time(
+        self, survival_function: pd.DataFrame
+    ) -> Union[float, pd.DataFrame]:
         return self.qth_survival_times(0.5, survival_function)
 
-    def qth_survival_times(self, q: float, survival_functions: pd.DataFrame) -> Union[float, pd.DataFrame]:
+    def qth_survival_times(
+        self, q: float, survival_functions: pd.DataFrame
+    ) -> Union[float, pd.DataFrame]:
         """
         Find the times when one or more survival functions reach the qth percentile.
         """
@@ -225,17 +232,23 @@ class KaplanMeierEstimator():
 
         if survival_functions.shape[1] == 1 and q.shape == (1,):
             q = q[0]
-            return survival_functions.apply(lambda s: self.qth_survival_time(q, s)).iloc[0]
+            return survival_functions.apply(
+                lambda s: self.qth_survival_time(q, s)
+            ).iloc[0]
         else:
-            d = {_q: survival_functions.apply(
-                lambda s: self.qth_survival_time(_q, s)) for _q in q}
+            d = {
+                _q: survival_functions.apply(lambda s: self.qth_survival_time(_q, s))
+                for _q in q
+            }
             survival_times = pd.DataFrame(d).T
             if q.duplicated().any():
                 survival_times = survival_times.loc[q]
 
             return survival_times
 
-    def qth_survival_time(self, q: float, survival_function: Union[pd.DataFrame, pd.Series]) -> float:
+    def qth_survival_time(
+        self, q: float, survival_function: Union[pd.DataFrame, pd.Series]
+    ) -> float:
         """
         Returns the time when a single survival function reaches the qth percentile, that is,
         solves  :math:`q = S(t)` for :math:`t`.
@@ -265,22 +278,32 @@ class KaplanMeierEstimator():
             pass
         return v
 
-    def calculate_bounds(self, times: np.array, probabilities: np.array, cumulative_sq: np.array, alpha=0.05) -> pd.DataFrame:
+    def calculate_bounds(
+        self,
+        times: np.array,
+        probabilities: np.array,
+        cumulative_sq: np.array,
+        alpha=0.05,
+    ) -> pd.DataFrame:
         # This method calculates confidence intervals using the exponential Greenwood formula.
         # See https://www.math.wustl.edu/%7Esawyer/handouts/greenwood.pdf
         z = norm.ppf(1 - alpha / 2)
         df = pd.DataFrame(index=times)
-        with np.errstate(divide="ignore", invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             v = np.array(np.log(probabilities)).reshape(-1, 1)
             cumulative_sq_ = np.array(cumulative_sq).reshape(-1, 1)
 
-            ci_labels = ["%s_lower_%g" %
-                         ("prob", 1 - alpha), "%s_upper_%g" % ("prob", 1 - alpha)]
+            ci_labels = [
+                "%s_lower_%g" % ("prob", 1 - alpha),
+                "%s_upper_%g" % ("prob", 1 - alpha),
+            ]
 
-            df[ci_labels[0]] = np.exp(-np.exp(np.log(-v) -
-                                              z * np.sqrt(cumulative_sq_) / v))
-            df[ci_labels[1]] = np.exp(-np.exp(np.log(-v) +
-                                              z * np.sqrt(cumulative_sq_) / v))
+            df[ci_labels[0]] = np.exp(
+                -np.exp(np.log(-v) - z * np.sqrt(cumulative_sq_) / v)
+            )
+            df[ci_labels[1]] = np.exp(
+                -np.exp(np.log(-v) + z * np.sqrt(cumulative_sq_) / v)
+            )
         return df.fillna(1.0)
 
     @staticmethod
@@ -293,10 +316,9 @@ class KaplanMeierEstimator():
         number_of_estimators = len(estimators)
         probabilities = np.zeros(shape=unique_times.shape)
         for i, time in enumerate(unique_times):
-            probabilities_sum = sum([
-                estimator.get_probability_at(time)
-                for estimator in estimators
-            ])
+            probabilities_sum = sum(
+                [estimator.get_probability_at(time) for estimator in estimators]
+            )
             probabilities[i] = probabilities_sum / number_of_estimators
 
         surv_info = SurvInfo(
@@ -304,12 +326,14 @@ class KaplanMeierEstimator():
             events_count=np.zeros(shape=unique_times.shape),
             censored_count=np.zeros(shape=unique_times.shape),
             at_risk_count=np.zeros(shape=unique_times.shape),
-            probability=probabilities
+            probability=probabilities,
         )
         avg_estimator = KaplanMeierEstimator()
         avg_estimator.surv_info = surv_info
         avg_estimator.interval = avg_estimator.calculate_interval()
-        avg_estimator.median_survival_time, avg_estimator.median_survival_time_cli = avg_estimator.calcualte_indicators()
+        avg_estimator.median_survival_time, avg_estimator.median_survival_time_cli = (
+            avg_estimator.calcualte_indicators()
+        )
         return avg_estimator
 
     def binary_search(self, arr, target):
@@ -317,11 +341,10 @@ class KaplanMeierEstimator():
         if index < self.len_of_times and arr[index] == target:
             return index
         else:
-            return (-index - 1)
+            return -index - 1
 
     def get_probability_at(self, time: int) -> float:
-        index = self.binary_search(
-            self.times, time)
+        index = self.binary_search(self.times, time)
 
         if index >= 0:
             return self.probabilities[index]
@@ -334,16 +357,14 @@ class KaplanMeierEstimator():
         return self.probabilities[index - 1]
 
     def get_events_count_at(self, time: int) -> int:
-        index = self.binary_search(
-            self.times, time)
+        index = self.binary_search(self.times, time)
         if index >= 0:
             return self.events_counts[index]
 
         return 0
 
     def get_at_risk_count_at(self, time: int) -> int:
-        index = self.binary_search(
-            self.times, time)
+        index = self.binary_search(self.times, time)
         if index >= 0:
             return self.at_risk_counts[index]
 
@@ -369,7 +390,9 @@ class KaplanMeierEstimator():
         return rev_km
 
     @staticmethod
-    def compare_estimators(kme1: KaplanMeierEstimator, kme2: KaplanMeierEstimator) -> dict(str, float):
+    def compare_estimators(
+        kme1: KaplanMeierEstimator, kme2: KaplanMeierEstimator
+    ) -> dict(str, float):
         results = dict()
 
         if (len(kme1.times) == 0) or (len(kme2.times) == 0):
@@ -407,22 +430,32 @@ class KaplanMeierEstimator():
         return results
 
     def get_dict(self) -> KaplanMeierEstimatorDict:
-        return KaplanMeierEstimatorDict({
-            "times": self.times.tolist(),
-            "events_count": self.events_counts.tolist(),
-            "censored_count": self.censored_counts.tolist(),
-            "at_risk_count": self.at_risk_counts.tolist(),
-            "probabilities": self.probabilities.tolist(),
-        })
+        return KaplanMeierEstimatorDict(
+            {
+                "times": self.times.tolist(),
+                "events_count": self.events_counts.tolist(),
+                "censored_count": self.censored_counts.tolist(),
+                "at_risk_count": self.at_risk_counts.tolist(),
+                "probabilities": self.probabilities.tolist(),
+            }
+        )
 
     @staticmethod
-    def log_rank(survival_time: np.ndarray, survival_status:  np.ndarray, covered_examples: np.ndarray, uncovered_examples: np.ndarray) -> float:  # pylint: disable=missing-function-docstring
+    def log_rank(
+        survival_time: np.ndarray,
+        survival_status: np.ndarray,
+        covered_examples: np.ndarray,
+        uncovered_examples: np.ndarray,
+    ) -> float:  # pylint: disable=missing-function-docstring
         covered_estimator = KaplanMeierEstimator().fit(
-            survival_time[covered_examples], survival_status[covered_examples])
+            survival_time[covered_examples], survival_status[covered_examples]
+        )
         uncovered_estimator = KaplanMeierEstimator().fit(
-            survival_time[uncovered_examples], survival_status[uncovered_examples])
+            survival_time[uncovered_examples], survival_status[uncovered_examples]
+        )
 
         stats_and_pvalue = KaplanMeierEstimator().compare_estimators(
-            covered_estimator, uncovered_estimator)
+            covered_estimator, uncovered_estimator
+        )
 
         return 1 - stats_and_pvalue["p_value"]

--- a/decision_rules/survival/ruleset.py
+++ b/decision_rules/survival/ruleset.py
@@ -3,12 +3,11 @@ Contains survival ruleset class.
 """
 from __future__ import annotations
 
-from typing import Optional
-from typing import Type
-from typing import Union
+from typing import Optional, Type, Union
 
 import numpy as np
 import pandas as pd
+
 from decision_rules.core.coverage import SurvivalCoverageInfodict
 from decision_rules.core.exceptions import InvalidStateError
 from decision_rules.core.metrics import AbstractRulesMetrics
@@ -20,11 +19,10 @@ from decision_rules.importances._survival.conditions import \
     SurvivalRuleSetConditionImportances
 from decision_rules.survival.kaplan_meier import KaplanMeierEstimator
 from decision_rules.survival.metrics import SurvivalRulesMetrics
-from decision_rules.survival.prediction import BestRulePredictionStrategy
-from decision_rules.survival.prediction import SurvivalPrediction
-from decision_rules.survival.prediction import VotingPredictionStrategy
-from decision_rules.survival.rule import SurvivalConclusion
-from decision_rules.survival.rule import SurvivalRule
+from decision_rules.survival.prediction import (BestRulePredictionStrategy,
+                                                SurvivalPrediction,
+                                                VotingPredictionStrategy)
+from decision_rules.survival.rule import SurvivalConclusion, SurvivalRule
 
 
 class SurvivalRuleSet(AbstractRuleSet):
@@ -124,6 +122,7 @@ class SurvivalRuleSet(AbstractRuleSet):
             y_train_sorted,
             skip_sorting=True  # skip sorting (dataset is already sorted)
         )
+        self.default_conclusion.value = self.default_conclusion.estimator.median_survival_time
         self._stored_default_conclusion = self.default_conclusion
 
         for rule in self.rules:

--- a/decision_rules/survival/ruleset.py
+++ b/decision_rules/survival/ruleset.py
@@ -1,6 +1,7 @@
 """
 Contains survival ruleset class.
 """
+
 from __future__ import annotations
 
 from typing import Optional, Type, Union
@@ -13,21 +14,24 @@ from decision_rules.core.exceptions import InvalidStateError
 from decision_rules.core.metrics import AbstractRulesMetrics
 from decision_rules.core.prediction import PredictionStrategy
 from decision_rules.core.ruleset import AbstractRuleSet
-from decision_rules.importances._survival.attributes import \
-    SurvivalRuleSetAttributeImportances
-from decision_rules.importances._survival.conditions import \
-    SurvivalRuleSetConditionImportances
+from decision_rules.importances._survival.attributes import (
+    SurvivalRuleSetAttributeImportances,
+)
+from decision_rules.importances._survival.conditions import (
+    SurvivalRuleSetConditionImportances,
+)
 from decision_rules.survival.kaplan_meier import KaplanMeierEstimator
 from decision_rules.survival.metrics import SurvivalRulesMetrics
-from decision_rules.survival.prediction import (BestRulePredictionStrategy,
-                                                SurvivalPrediction,
-                                                VotingPredictionStrategy)
+from decision_rules.survival.prediction import (
+    BestRulePredictionStrategy,
+    SurvivalPrediction,
+    VotingPredictionStrategy,
+)
 from decision_rules.survival.rule import SurvivalConclusion, SurvivalRule
 
 
 class SurvivalRuleSet(AbstractRuleSet):
-    """Survival ruleset allowing to perform prediction on data
-    """
+    """Survival ruleset allowing to perform prediction on data"""
 
     def __init__(
         self,
@@ -42,16 +46,16 @@ class SurvivalRuleSet(AbstractRuleSet):
         super().__init__(rules)
         self.survival_time_attr_name: str = survival_time_attr
         self.decision_attribute: str = (
-            self.rules[0].conclusion.column_name
-            if len(rules) > 0 else None
+            self.rules[0].conclusion.column_name if len(rules) > 0 else None
         )
         self.default_conclusion = SurvivalConclusion(
-            value=None,
-            column_name=self.decision_attribute
+            value=None, column_name=self.decision_attribute
         )
         self._stored_default_conclusion = self.default_conclusion
 
-    def _calculate_P_N(self, y_uniques: np.ndarray, y_values_count: np.ndarray):  # pylint: disable=invalid-name
+    def _calculate_P_N(
+        self, y_uniques: np.ndarray, y_values_count: np.ndarray
+    ):  # pylint: disable=invalid-name
         return
 
     def get_metrics_object_instance(self) -> AbstractRulesMetrics:
@@ -67,32 +71,33 @@ class SurvivalRuleSet(AbstractRuleSet):
         for rule in self.rules:
             coverage_info: SurvivalCoverageInfodict = coverages_info[rule.uuid]
             rule.conclusion.estimator.update(
-                coverage_info['kaplan_meier_estimator'],
-                update_additional_indicators=True
+                coverage_info["kaplan_meier_estimator"],
+                update_additional_indicators=True,
             )
-            rule.conclusion.value = coverage_info['median_survival_time']
+            rule.conclusion.value = coverage_info["median_survival_time"]
             rule.conclusion.median_survival_time_ci_lower = coverage_info[
-                'median_survival_time_ci_lower']
+                "median_survival_time_ci_lower"
+            ]
             rule.conclusion.median_survival_time_ci_upper = coverage_info[
-                'median_survival_time_ci_upper']
-            rule.conclusion.estimator.events_count = coverage_info['events_count']
-            rule.conclusion.estimator.censored_count = coverage_info['censored_count']
-            rule.log_rank = coverage_info['log_rank']
+                "median_survival_time_ci_upper"
+            ]
+            rule.conclusion.estimator.events_count = coverage_info["events_count"]
+            rule.conclusion.estimator.censored_count = coverage_info["censored_count"]
+            rule.log_rank = coverage_info["log_rank"]
 
-        super().update_using_coverages(coverages_info,
-                                       KaplanMeierEstimator.log_rank, columns_names)
+        super().update_using_coverages(
+            coverages_info, KaplanMeierEstimator.log_rank, columns_names
+        )
 
     def update(
-        self,
-        X_train: pd.DataFrame,
-        y_train: pd.Series,
-        _measure=None
+        self, X_train: pd.DataFrame, y_train: pd.Series, _measure=None
     ) -> np.ndarray:
         # the `measure` is always `log_rank` for survival rulesets,
         # but the parameter is kept for compatibility with other types
         if _measure is not None:
             raise ValueError(
-                "The parameter `measure` should not be set for `SurvivalRuleSet` - `log_rank` will always be used.")
+                "The parameter `measure` should not be set for `SurvivalRuleSet` - `log_rank` will always be used."
+            )
 
         if len(self.rules) == 0:
             raise ValueError(
@@ -102,8 +107,7 @@ class SurvivalRuleSet(AbstractRuleSet):
         if self.column_names is None:
             self.column_names = X_train.columns.tolist()
         # sort data by survival time
-        survival_time_attr_index = self.column_names.index(
-            self.survival_time_attr_name)
+        survival_time_attr_index = self.column_names.index(self.survival_time_attr_name)
         X_train, y_train = self._sanitize_dataset(X_train, y_train)
         survival_time = X_train[:, survival_time_attr_index]
         sorted_indices = np.argsort(survival_time)
@@ -113,16 +117,17 @@ class SurvivalRuleSet(AbstractRuleSet):
 
         # fit Kaplan Meier estimator on whole dataset as default conclusion
         self.default_conclusion = SurvivalConclusion(
-            value=None,
-            column_name=self.decision_attribute
+            value=None, column_name=self.decision_attribute
         )
         self.default_conclusion.estimator = KaplanMeierEstimator()
         self.default_conclusion.estimator.fit(
             survival_time_sorted,
             y_train_sorted,
-            skip_sorting=True  # skip sorting (dataset is already sorted)
+            skip_sorting=True,  # skip sorting (dataset is already sorted)
         )
-        self.default_conclusion.value = self.default_conclusion.estimator.median_survival_time
+        self.default_conclusion.value = (
+            self.default_conclusion.estimator.median_survival_time
+        )
         self._stored_default_conclusion = self.default_conclusion
 
         for rule in self.rules:
@@ -132,7 +137,7 @@ class SurvivalRuleSet(AbstractRuleSet):
         coverage_matrix: np.ndarray = self.calculate_rules_coverages(
             X_train_sorted,
             y_train_sorted,
-            skip_sorting=True  # skip sorting (dataset is already sorted)
+            skip_sorting=True,  # skip sorting (dataset is already sorted)
         )
         self.calculate_rules_weights(KaplanMeierEstimator.log_rank)
 
@@ -143,15 +148,14 @@ class SurvivalRuleSet(AbstractRuleSet):
         self,
         X: pd.DataFrame,  # pylint: disable=invalid-name
         y: pd.Series,  # pylint: disable=invalid-name
-        metrics_to_calculate: Optional[list[str]] = None
+        metrics_to_calculate: Optional[list[str]] = None,
     ) -> dict[dict[str, str, float]]:
         for rule in self.rules:
             rule.premise.cached = True
         try:
             self.update(X, y)
             metrics: SurvivalRulesMetrics = self.get_metrics_object_instance()
-            metrics_values: dict = metrics.calculate(
-                X, y, metrics_to_calculate)
+            metrics_values: dict = metrics.calculate(X, y, metrics_to_calculate)
             return metrics_values
         except Exception as e:
             raise e
@@ -159,10 +163,7 @@ class SurvivalRuleSet(AbstractRuleSet):
             for rule in self.rules:
                 rule.premise.invalidate_cache()
 
-    def calculate_rules_weights(
-        self,
-        measure=None
-    ):
+    def calculate_rules_weights(self, measure=None):
         """
         Args:
             measure: quality measure function, in case of Survival it is always log_rank or if not specified, then voting_weight is 1
@@ -177,30 +178,38 @@ class SurvivalRuleSet(AbstractRuleSet):
             for rule in self.rules:
                 if rule.log_rank is None:
                     raise ValueError(
-                        'Tried to calculate voting weight of a rule with uncalculated log_rank.' +
-                        'You should either call `RuleSet.calculate_rules_coverages` method - to ' +
-                        'calculate log_rank of all rules - or call `Rule.calculate_coverage` ' +
-                        '- to calculate coverage of this specific rule'
+                        "Tried to calculate voting weight of a rule with uncalculated log_rank."
+                        + "You should either call `RuleSet.calculate_rules_coverages` method - to "
+                        + "calculate log_rank of all rules - or call `Rule.calculate_coverage` "
+                        + "- to calculate coverage of this specific rule"
                     )
                 rule.voting_weight = rule.log_rank
         self._voting_weights_calculated = True
 
-    def calculate_condition_importances(self, X: pd.DataFrame, y: pd.Series, *args) -> dict[str, float]:
+    def calculate_condition_importances(
+        self, X: pd.DataFrame, y: pd.Series, *args
+    ) -> dict[str, float]:
         X, y = self._sanitize_dataset(X, y)
-        condtion_importances_generator = SurvivalRuleSetConditionImportances(
-            self)
-        self.condition_importances = condtion_importances_generator.calculate_importances(
-            X, y
+        condtion_importances_generator = SurvivalRuleSetConditionImportances(self)
+        self.condition_importances = (
+            condtion_importances_generator.calculate_importances(X, y)
         )
         return self.condition_importances
 
-    def calculate_attribute_importances(self, condition_importances: dict[str, float]) -> dict[str, float]:
+    def calculate_attribute_importances(
+        self, condition_importances: dict[str, float]
+    ) -> dict[str, float]:
         attributes_importances_generator = SurvivalRuleSetAttributeImportances()
-        self.attribute_importances = attributes_importances_generator.calculate_importances_base_on_conditions(
-            condition_importances)
+        self.attribute_importances = (
+            attributes_importances_generator.calculate_importances_base_on_conditions(
+                condition_importances
+            )
+        )
         return self.attribute_importances
 
-    def local_explainability(self, x: pd.Series) -> tuple[list[str], SurvivalPrediction]:  # pylint: disable=invalid-name
+    def local_explainability(
+        self, x: pd.Series
+    ) -> tuple[list[str], SurvivalPrediction]:  # pylint: disable=invalid-name
         """Calculate local explainability of ruleset for given instance.
 
         Args:
@@ -217,16 +226,12 @@ class SurvivalRuleSet(AbstractRuleSet):
         )[0]
 
         rules_covering_instance = [
-            rule.uuid for i, rule in enumerate(self.rules)
-            if coverage_matrix[0][i]
+            rule.uuid for i, rule in enumerate(self.rules) if coverage_matrix[0][i]
         ]
         return rules_covering_instance, prediction
 
     def integrated_bier_score(
-        self,
-        X: pd.DataFrame,
-        y: pd.Series,
-        y_pred: Optional[np.ndarray] = None
+        self, X: pd.DataFrame, y: pd.Series, y_pred: Optional[np.ndarray] = None
     ) -> float:
         """Calculate Integrated Brier Score (IBS)
 
@@ -246,13 +251,15 @@ class SurvivalRuleSet(AbstractRuleSet):
 
         if self._stored_default_conclusion is None:
             raise InvalidStateError(
-                'Cannot calculate IBS without default conclusion. ' +
-                'Maybe you forgot to call update(...) method?'
+                "Cannot calculate IBS without default conclusion. "
+                + "Maybe you forgot to call update(...) method?"
             )
 
-        censoring_KM: KaplanMeierEstimator = self._stored_default_conclusion.estimator.reverse()
+        censoring_KM: KaplanMeierEstimator = (
+            self._stored_default_conclusion.estimator.reverse()
+        )
 
-        censored_events_mask = survival_status == '0'
+        censored_events_mask = survival_status == "0"
         info_list: list[_IBSInfo] = []
         prediction: np.ndarray = self.predict(X) if y_pred is None else y_pred
         zipped_data = zip(survival_times, censored_events_mask, prediction)
@@ -287,7 +294,7 @@ class SurvivalRuleSet(AbstractRuleSet):
                             p = 1 - si.estimator.get_probability_at(bt)
                             brier_sum += (p * p) / g
 
-                brier_score.append(brier_sum/info_size)
+                brier_score.append(brier_sum / info_size)
             prev_info = info
 
         diffs: list[float] = []
@@ -295,10 +302,7 @@ class SurvivalRuleSet(AbstractRuleSet):
         for i in range(1, info_size):
             diffs.append(sorted_info[i].time - sorted_info[i - 1].time)
 
-        score_sum = sum([
-            diffs[i] * brier_score[i]
-            for i in range(info_size)
-        ])
+        score_sum = sum([diffs[i] * brier_score[i] for i in range(info_size)])
         score = score_sum / sorted_info[info_size - 1].time
 
         return score
@@ -307,7 +311,7 @@ class SurvivalRuleSet(AbstractRuleSet):
         self,
         X: Union[np.ndarray, pd.DataFrame],
         y: Optional[Union[np.ndarray, pd.Series]] = None,
-        to_numpy: bool = True
+        to_numpy: bool = True,
     ) -> Union[tuple[np.ndarray, np.ndarray], np.ndarray]:
         res = super()._sanitize_dataset(X, y, to_numpy)
         if y is not None:
@@ -316,21 +320,24 @@ class SurvivalRuleSet(AbstractRuleSet):
         return res
 
     def _validate_survival_status_column(self, survival_status: np.ndarray):
-        if set(np.unique(survival_status)) - {'0', '1'}:
+        if set(np.unique(survival_status)) - {"0", "1"}:
             raise ValueError(
-                'y (survival status) must be of string type and contain only "0" and "1" values.')
+                'y (survival status) must be of string type and contain only "0" and "1" values.'
+            )
 
     def _map_prediction_values(self, predictions: np.ndarray) -> np.ndarray:
-        return np.array([
-            SurvivalPrediction.from_kaplan_meier(kaplan_meier)
-            for kaplan_meier in predictions
-        ])
+        return np.array(
+            [
+                SurvivalPrediction.from_kaplan_meier(kaplan_meier)
+                for kaplan_meier in predictions
+            ]
+        )
 
     @property
     def prediction_strategies_choice(self) -> dict[str, Type[PredictionStrategy]]:
         return {
-            'vote': VotingPredictionStrategy,
-            'best_rule': BestRulePredictionStrategy,
+            "vote": VotingPredictionStrategy,
+            "best_rule": BestRulePredictionStrategy,
         }
 
     def get_default_prediction_strategy_class(self) -> Type[PredictionStrategy]:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-module-docstring
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='decision_rules',
@@ -8,7 +7,7 @@ setup(
         "Package implementing decision rules. Includes tools for calculations of various measures "
         "and indicators, as well as algorithms for filtering rulesets."
     ),
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     version='1.1.0',
     author='Cezary Maszczyk, Dawid Macha, Adam Grzelak, Bartosz Piguła',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     ),
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    version='1.1.0',
+    version='1.2.0',
     author='Cezary Maszczyk, Dawid Macha, Adam Grzelak, Bartosz Piguła',
     author_email='cezary.maszczyk@emag.lukasiewicz.gov.pl',
     readme='README.md',

--- a/tests/base_tests/serialization/classification/test_ruleset_serializer.py
+++ b/tests/base_tests/serialization/classification/test_ruleset_serializer.py
@@ -21,56 +21,60 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         rule1 = ClassificationRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=2, column_right=3, operator='>'
-                    ),
+                    AttributesCondition(column_left=2, column_right=3, operator=">"),
                     ElementaryCondition(
-                        column_index=2, left=-1, right=2.0, left_closed=True, right_closed=False
+                        column_index=2,
+                        left=-1,
+                        right=2.0,
+                        left_closed=True,
+                        right_closed=False,
                     ),
                     NominalCondition(
                         column_index=2,
-                        value='value',
-                    )
+                        value="value",
+                    ),
                 ],
-                logic_operator=LogicOperators.ALTERNATIVE
+                logic_operator=LogicOperators.ALTERNATIVE,
             ),
-            conclusion=ClassificationConclusion(2, column_name='class'),
-            column_names=list(range(4))
+            conclusion=ClassificationConclusion(2, column_name="class"),
+            column_names=list(range(4)),
         )
         rule1.coverage = Coverage(p=10, n=2, P=12, N=20)
         rule2 = ClassificationRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=1, column_right=3, operator='<'
-                    ),
+                    AttributesCondition(column_left=1, column_right=3, operator="<"),
                     NominalCondition(
                         column_index=1,
-                        value='value',
+                        value="value",
                     ),
                     ElementaryCondition(
                         column_index=2,
-                        left=float('-inf'),
+                        left=float("-inf"),
                         right=3.0,
                         left_closed=False,
-                        right_closed=False
+                        right_closed=False,
                     ),
                 ],
-                logic_operator=LogicOperators.CONJUNCTION
+                logic_operator=LogicOperators.CONJUNCTION,
             ),
-            conclusion=ClassificationConclusion(1, column_name='class'),
-            column_names=list(range(4))
+            conclusion=ClassificationConclusion(1, column_name="class"),
+            column_names=list(range(4)),
         )
         rule2.coverage = Coverage(p=19, n=1, P=20, N=12)
-        return ClassificationRuleSet([rule1, rule2])  # pylint: disable=abstract-class-instantiated
+        return ClassificationRuleSet(
+            [rule1, rule2]
+        )  # pylint: disable=abstract-class-instantiated
 
     def _prepare_dataset(self) -> tuple[pd.DataFrame, pd.Series]:
-        X: pd.DataFrame = pd.DataFrame({
-            'col_1': range(6),
-            'col_2': range(6),
-            'col_3': range(6),
-            'col_4': range(6),
-        })
+        X: pd.DataFrame = pd.DataFrame(
+            {
+                "col_1": range(6),
+                "col_2": range(6),
+                "col_3": range(6),
+                "col_4": range(6),
+            }
+        )
         y: pd.Series = pd.Series([1, 2, 2, 1, 2, 1])
         return X, y
 
@@ -87,8 +91,9 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         ruleset.predict(X)
 
         self.assertEqual(
-            ruleset, deserializer_ruleset,
-            'Serializing and deserializing should lead to the the same object'
+            ruleset,
+            deserializer_ruleset,
+            "Serializing and deserializing should lead to the the same object",
         )
 
     def test_serializing_deserializing_using_update_using_coverages(self):
@@ -96,12 +101,7 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         X, _ = self._prepare_dataset()
         ruleset.update_using_coverages(
             coverages_info={
-                rule.uuid: {
-                    'p': 10,
-                    'n': 0,
-                    'P': 20,
-                    'N': 20
-                } for rule in ruleset.rules
+                rule.uuid: {"p": 10, "n": 0, "P": 20, "N": 20} for rule in ruleset.rules
             },
             measure=measures.accuracy,
             columns_names=X.columns.tolist(),
@@ -114,8 +114,9 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         )
 
         self.assertEqual(
-            ruleset, deserializer_ruleset,
-            'Serializing and deserializing should lead to the the same object'
+            ruleset,
+            deserializer_ruleset,
+            "Serializing and deserializing should lead to the the same object",
         )
 
     def test_serializing_deserializing_without_coverages(self):
@@ -131,8 +132,9 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         ruleset.predict(X)
 
         self.assertEqual(
-            ruleset, deserializer_ruleset,
-            'Serializing and deserializing should lead to the the same object'
+            ruleset,
+            deserializer_ruleset,
+            "Serializing and deserializing should lead to the the same object",
         )
 
     def test_prediction_after_deserializing_without_update(self):
@@ -160,24 +162,24 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         self.assertEqual(
             ruleset.default_conclusion.value,
             deserialized_ruleset_full.default_conclusion.value,
-            'Default conclusion after deserializing should be the same'
+            "Default conclusion after deserializing should be the same",
         )
         self.assertEqual(
             [r.coverage for r in ruleset.rules],
             [r.coverage for r in deserialized_ruleset_full.rules],
-            'Coverages after deserializing should be the same'
+            "Coverages after deserializing should be the same",
         )
         self.assertEqual(
             [r.voting_weight for r in ruleset.rules],
             [r.voting_weight for r in deserialized_ruleset_full.rules],
-            'Voting weights after deserializing should be the same'
+            "Voting weights after deserializing should be the same",
         )
         self.assertEqual(
             ruleset.predict(X).tolist(),
             deserialized_ruleset_full.predict(X).tolist(),
-            'Prediction after deserializing should be the same'
+            "Prediction after deserializing should be the same",
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/base_tests/serialization/classification/test_ruleset_serializer.py
+++ b/tests/base_tests/serialization/classification/test_ruleset_serializer.py
@@ -11,7 +11,8 @@ from decision_rules.conditions import (AttributesCondition, CompoundCondition,
                                        ElementaryCondition, LogicOperators,
                                        NominalCondition)
 from decision_rules.core.coverage import Coverage
-from decision_rules.serialization import JSONSerializer
+from decision_rules.core.exceptions import InvalidStateError
+from decision_rules.serialization import JSONSerializer, SerializationModes
 
 
 class TestClassificationRuleSetSerializer(unittest.TestCase):
@@ -61,7 +62,7 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
             column_names=list(range(4))
         )
         rule2.coverage = Coverage(p=19, n=1, P=20, N=12)
-        return ClassificationRuleSet([rule1, rule2]) # pylint: disable=abstract-class-instantiated
+        return ClassificationRuleSet([rule1, rule2])  # pylint: disable=abstract-class-instantiated
 
     def _prepare_dataset(self) -> tuple[pd.DataFrame, pd.Series]:
         X: pd.DataFrame = pd.DataFrame({
@@ -122,8 +123,6 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         X, y = self._prepare_dataset()
 
         ruleset.update(X, y, measure=measures.accuracy)
-        for rule in ruleset.rules:
-            rule.coverage = None
 
         serialized_ruleset = JSONSerializer.serialize(ruleset)
         deserializer_ruleset = JSONSerializer.deserialize(
@@ -140,32 +139,42 @@ class TestClassificationRuleSetSerializer(unittest.TestCase):
         ruleset: ClassificationRuleSet = self._prepare_ruleset()
         X, y = self._prepare_dataset()
         ruleset.update(X, y, measure=measures.accuracy)
-                # change conclusion value so it will be different than the default one
-        ruleset.default_conclusion.value = 1
+        # change conclusion value so it will be different than the default one
+        ruleset.default_conclusion.value += 1
 
-        serialized_ruleset: dict = JSONSerializer.serialize(ruleset)
-        deserializer_ruleset: ClassificationRuleSet = JSONSerializer.deserialize(
-            serialized_ruleset, ClassificationRuleSet
+        serialized_ruleset_min: dict = JSONSerializer.serialize(
+            ruleset, mode=SerializationModes.MINIMAL
         )
+        serialized_ruleset_full: dict = JSONSerializer.serialize(
+            ruleset, mode=SerializationModes.FULL
+        )
+        deserializer_ruleset_min: ClassificationRuleSet = JSONSerializer.deserialize(
+            serialized_ruleset_min, ClassificationRuleSet
+        )
+        deserialized_ruleset_full: ClassificationRuleSet = JSONSerializer.deserialize(
+            serialized_ruleset_full, ClassificationRuleSet
+        )
+        with self.assertRaises(InvalidStateError):
+            deserializer_ruleset_min.predict(X)
 
         self.assertEqual(
             ruleset.default_conclusion.value,
-            deserializer_ruleset.default_conclusion.value,
+            deserialized_ruleset_full.default_conclusion.value,
             'Default conclusion after deserializing should be the same'
         )
         self.assertEqual(
             [r.coverage for r in ruleset.rules],
-            [r.coverage for r in deserializer_ruleset.rules],
+            [r.coverage for r in deserialized_ruleset_full.rules],
             'Coverages after deserializing should be the same'
         )
         self.assertEqual(
             [r.voting_weight for r in ruleset.rules],
-            [r.voting_weight for r in deserializer_ruleset.rules],
+            [r.voting_weight for r in deserialized_ruleset_full.rules],
             'Voting weights after deserializing should be the same'
         )
         self.assertEqual(
             ruleset.predict(X).tolist(),
-            deserializer_ruleset.predict(X).tolist(),
+            deserialized_ruleset_full.predict(X).tolist(),
             'Prediction after deserializing should be the same'
         )
 

--- a/tests/base_tests/serialization/regression/test_ruleset_serializer.py
+++ b/tests/base_tests/serialization/regression/test_ruleset_serializer.py
@@ -2,22 +2,20 @@
 import unittest
 
 import pandas as pd
+
 from decision_rules import measures
-from decision_rules.conditions import AttributesCondition
-from decision_rules.conditions import CompoundCondition
-from decision_rules.conditions import ElementaryCondition
-from decision_rules.conditions import LogicOperators
-from decision_rules.conditions import NominalCondition
+from decision_rules.conditions import (AttributesCondition, CompoundCondition,
+                                       ElementaryCondition, LogicOperators,
+                                       NominalCondition)
 from decision_rules.core.coverage import Coverage
-from decision_rules.regression.rule import RegressionConclusion
-from decision_rules.regression.rule import RegressionRule
+from decision_rules.regression.rule import RegressionConclusion, RegressionRule
 from decision_rules.regression.ruleset import RegressionRuleSet
 from decision_rules.serialization import JSONSerializer
 
 
 class TestRegressionRuleSetSerializer(unittest.TestCase):
 
-    def test_serializing_deserializing(self):
+    def _prepare_ruleset(self) -> RegressionRuleSet:
         rule1 = RegressionRule(
             CompoundCondition(
                 subconditions=[
@@ -60,7 +58,9 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
             column_names=['col_1', 'col_2', 'col_3', 'col_4']
         )
         rule2.coverage = Coverage(p=19, n=1, P=20, N=12)
-        ruleset = RegressionRuleSet([rule1, rule2])
+        return RegressionRuleSet([rule1, rule2]) # pylint: disable=abstract-class-instantiated
+
+    def _prepare_dataset(self) -> tuple[pd.DataFrame, pd.Series]:
         X: pd.DataFrame = pd.DataFrame({
             'col_1': range(6),
             'col_2': range(6),
@@ -68,6 +68,11 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
             'col_4': range(6),
         })
         y: pd.Series = pd.Series([1, 2, 2, 1, 2, 1])
+        return X, y
+
+    def test_serializing_deserializing(self):
+        ruleset: RegressionRuleSet = self._prepare_ruleset()
+        X, y = self._prepare_dataset()
         ruleset.update(X, y, measure=measures.accuracy)
 
         serialized_ruleset = JSONSerializer.serialize(ruleset)
@@ -78,6 +83,40 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
         self.assertEqual(
             ruleset, deserializer_ruleset,
             'Serializing and deserializing should lead to the the same object'
+        )
+
+    def test_prediction_after_deserializing_without_update(self):
+        ruleset: RegressionRuleSet = self._prepare_ruleset()
+        X, y = self._prepare_dataset()
+        ruleset.update(X, y, measure=measures.accuracy)
+        # change conclusion value so it will be different than the default one
+        ruleset.default_conclusion.high += 0.01 
+        ruleset.default_conclusion.value += 0.01 
+
+        serialized_ruleset: dict = JSONSerializer.serialize(ruleset)
+        deserializer_ruleset: RegressionRuleSet = JSONSerializer.deserialize(
+            serialized_ruleset, RegressionRuleSet
+        )
+
+        self.assertEqual(
+            ruleset.default_conclusion.value,
+            deserializer_ruleset.default_conclusion.value,
+            'Default conclusion after deserializing should be the same'
+        )
+        self.assertEqual(
+            [r.coverage for r in ruleset.rules],
+            [r.coverage for r in deserializer_ruleset.rules],
+            'Coverages after deserializing should be the same'
+        )
+        self.assertEqual(
+            [r.voting_weight for r in ruleset.rules],
+            [r.voting_weight for r in deserializer_ruleset.rules],
+            'Voting weights after deserializing should be the same'
+        )
+        self.assertEqual(
+            ruleset.predict(X).tolist(),
+            deserializer_ruleset.predict(X).tolist(),
+            'Prediction after deserializing should be the same'
         )
 
 

--- a/tests/base_tests/serialization/regression/test_ruleset_serializer.py
+++ b/tests/base_tests/serialization/regression/test_ruleset_serializer.py
@@ -20,54 +20,60 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
         rule1 = RegressionRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=2, column_right=3, operator='>'
-                    ),
+                    AttributesCondition(column_left=2, column_right=3, operator=">"),
                     ElementaryCondition(
-                        column_index=2, left=-1, right=2.0, left_closed=True, right_closed=False
+                        column_index=2,
+                        left=-1,
+                        right=2.0,
+                        left_closed=True,
+                        right_closed=False,
                     ),
                     NominalCondition(
                         column_index=2,
-                        value='value',
-                    )
+                        value="value",
+                    ),
                 ],
-                logic_operator=LogicOperators.ALTERNATIVE
+                logic_operator=LogicOperators.ALTERNATIVE,
             ),
             conclusion=RegressionConclusion(
-                1.0, low=0.5, high=1.5, column_name='label'),
-            column_names=['col_1', 'col_2', 'col_3', 'col_4']
+                1.0, low=0.5, high=1.5, column_name="label"
+            ),
+            column_names=["col_1", "col_2", "col_3", "col_4"],
         )
         rule1.coverage = Coverage(p=10, n=2, P=12, N=20)
         rule2 = RegressionRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=1, column_right=3, operator='='
-                    ),
+                    AttributesCondition(column_left=1, column_right=3, operator="="),
                     ElementaryCondition(
                         column_index=2,
-                        left=float('-inf'),
+                        left=float("-inf"),
                         right=3.0,
                         left_closed=False,
-                        right_closed=False
+                        right_closed=False,
                     ),
                 ],
-                logic_operator=LogicOperators.CONJUNCTION
+                logic_operator=LogicOperators.CONJUNCTION,
             ),
             conclusion=RegressionConclusion(
-                1.0, low=0.5, high=1.5, column_name='label'),
-            column_names=['col_1', 'col_2', 'col_3', 'col_4']
+                1.0, low=0.5, high=1.5, column_name="label"
+            ),
+            column_names=["col_1", "col_2", "col_3", "col_4"],
         )
         rule2.coverage = Coverage(p=19, n=1, P=20, N=12)
-        return RegressionRuleSet([rule1, rule2])  # pylint: disable=abstract-class-instantiated
+        return RegressionRuleSet(
+            [rule1, rule2]
+        )  # pylint: disable=abstract-class-instantiated
 
     def _prepare_dataset(self) -> tuple[pd.DataFrame, pd.Series]:
-        X: pd.DataFrame = pd.DataFrame({
-            'col_1': range(6),
-            'col_2': range(6),
-            'col_3': range(6),
-            'col_4': range(6),
-        })
+        X: pd.DataFrame = pd.DataFrame(
+            {
+                "col_1": range(6),
+                "col_2": range(6),
+                "col_3": range(6),
+                "col_4": range(6),
+            }
+        )
         y: pd.Series = pd.Series([1, 2, 2, 1, 2, 1])
         return X, y
 
@@ -82,8 +88,9 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
         )
 
         self.assertEqual(
-            ruleset, deserializer_ruleset,
-            'Serializing and deserializing should lead to the the same object'
+            ruleset,
+            deserializer_ruleset,
+            "Serializing and deserializing should lead to the the same object",
         )
 
     def test_prediction_after_deserializing_without_update(self):
@@ -112,24 +119,24 @@ class TestRegressionRuleSetSerializer(unittest.TestCase):
         self.assertEqual(
             ruleset.default_conclusion.value,
             deserialized_ruleset_full.default_conclusion.value,
-            'Default conclusion after deserializing should be the same'
+            "Default conclusion after deserializing should be the same",
         )
         self.assertEqual(
             [r.coverage for r in ruleset.rules],
             [r.coverage for r in deserialized_ruleset_full.rules],
-            'Coverages after deserializing should be the same'
+            "Coverages after deserializing should be the same",
         )
         self.assertEqual(
             [r.voting_weight for r in ruleset.rules],
             [r.voting_weight for r in deserialized_ruleset_full.rules],
-            'Voting weights after deserializing should be the same'
+            "Voting weights after deserializing should be the same",
         )
         self.assertEqual(
             ruleset.predict(X).tolist(),
             deserialized_ruleset_full.predict(X).tolist(),
-            'Prediction after deserializing should be the same'
+            "Prediction after deserializing should be the same",
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/base_tests/serialization/survival/test_ruleset_serializer.py
+++ b/tests/base_tests/serialization/survival/test_ruleset_serializer.py
@@ -21,22 +21,24 @@ class TestSurvivalRuleSetSerializer(unittest.TestCase):
         rule1 = SurvivalRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=2, column_right=3, operator='>'
-                    ),
+                    AttributesCondition(column_left=2, column_right=3, operator=">"),
                     ElementaryCondition(
-                        column_index=2, left=-1, right=2.0, left_closed=True, right_closed=False
+                        column_index=2,
+                        left=-1,
+                        right=2.0,
+                        left_closed=True,
+                        right_closed=False,
                     ),
                     NominalCondition(
                         column_index=2,
-                        value='value',
-                    )
+                        value="value",
+                    ),
                 ],
-                logic_operator=LogicOperators.ALTERNATIVE
+                logic_operator=LogicOperators.ALTERNATIVE,
             ),
-            conclusion=SurvivalConclusion(1.0, column_name='label'),
-            column_names=['col_1', 'col_2', 'col_3', 'col_4', 'survival_time'],
-            survival_time_attr='survival_time'
+            conclusion=SurvivalConclusion(1.0, column_name="label"),
+            column_names=["col_1", "col_2", "col_3", "col_4", "survival_time"],
+            survival_time_attr="survival_time",
         )
         rule1.coverage = Coverage(p=10, n=2, P=12, N=20)
         rule1.conclusion.median_survival_time_ci_lower = 1.0
@@ -44,57 +46,54 @@ class TestSurvivalRuleSetSerializer(unittest.TestCase):
         rule2 = SurvivalRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=1, column_right=3, operator='='
-                    ),
+                    AttributesCondition(column_left=1, column_right=3, operator="="),
                     ElementaryCondition(
                         column_index=2,
-                        left=float('-inf'),
+                        left=float("-inf"),
                         right=3.0,
                         left_closed=False,
-                        right_closed=False
+                        right_closed=False,
                     ),
                 ],
-                logic_operator=LogicOperators.CONJUNCTION
+                logic_operator=LogicOperators.CONJUNCTION,
             ),
-            conclusion=SurvivalConclusion(1.0, column_name='label'),
-            column_names=['col_1', 'col_2', 'col_3', 'col_4', 'survival_time'],
-            survival_time_attr='survival_time'
+            conclusion=SurvivalConclusion(1.0, column_name="label"),
+            column_names=["col_1", "col_2", "col_3", "col_4", "survival_time"],
+            survival_time_attr="survival_time",
         )
         rule2.coverage = Coverage(p=19, n=1, P=20, N=12)
         rule2.conclusion.median_survival_time_ci_lower = 1.0
         rule2.conclusion.median_survival_time_ci_upper = 3.0
         ruleset = SurvivalRuleSet(  # pylint: disable=abstract-class-instantiated
-            rules=[rule1, rule2],
-            survival_time_attr='survival_time'
+            rules=[rule1, rule2], survival_time_attr="survival_time"
         )
         conclusion_estimator_dict = {
-            'times': [1.1, 2.1, 3.0, 10, 22.2],
-            'events_count': [1.0, 0, 1.0, 1.0, 0],
-            'censored_count': [0.0, 1.0, 2.0, 0.0, 5.0],
-            'at_risk_count': [75.0, 21.0, 5.0, 1.0, 0.0],
-            'probabilities': [0.98, 0.92, 0.76, 0.52, 0.31]
+            "times": [1.1, 2.1, 3.0, 10, 22.2],
+            "events_count": [1.0, 0, 1.0, 1.0, 0],
+            "censored_count": [0.0, 1.0, 2.0, 0.0, 5.0],
+            "at_risk_count": [75.0, 21.0, 5.0, 1.0, 0.0],
+            "probabilities": [0.98, 0.92, 0.76, 0.52, 0.31],
         }
         ruleset.default_conclusion = SurvivalConclusion(
-            value=0.0,
-            column_name=ruleset.rules[0].conclusion.column_name
+            value=0.0, column_name=ruleset.rules[0].conclusion.column_name
         )
         ruleset.default_conclusion.estimator = KaplanMeierEstimator().update(
             conclusion_estimator_dict, update_additional_indicators=True
         )
-        ruleset.column_names = ['col_1', 'col_2',
-                                'col_3', 'col_4', 'survival_time']
+        ruleset.column_names = ["col_1", "col_2", "col_3", "col_4", "survival_time"]
         return ruleset
 
     def _prepare_dataset(self) -> tuple[pd.DataFrame, pd.Series]:
-        X: pd.DataFrame = pd.DataFrame({
-            'col_1': range(5),
-            'col_2': range(5),
-            'col_3': range(5),
-            'col_4': range(5),
-            'survival_time': range(5),
-        })
-        y: pd.Series = pd.Series(['0', '1', '0', '1', '0'])
+        X: pd.DataFrame = pd.DataFrame(
+            {
+                "col_1": range(5),
+                "col_2": range(5),
+                "col_3": range(5),
+                "col_4": range(5),
+                "survival_time": range(5),
+            }
+        )
+        y: pd.Series = pd.Series(["0", "1", "0", "1", "0"])
         return X, y
 
     def test_serializing_deserializing(self):
@@ -106,8 +105,9 @@ class TestSurvivalRuleSetSerializer(unittest.TestCase):
         )
 
         self.assertEqual(
-            ruleset, deserializer_ruleset,
-            'Serializing and deserializing should lead to the the same object'
+            ruleset,
+            deserializer_ruleset,
+            "Serializing and deserializing should lead to the the same object",
         )
 
     def test_prediction_after_deserializing_without_update(self):
@@ -136,26 +136,26 @@ class TestSurvivalRuleSetSerializer(unittest.TestCase):
         self.assertEqual(
             ruleset.default_conclusion.value,
             deserialized_ruleset_full.default_conclusion.value,
-            'Default conclusion after deserializing should be the same'
+            "Default conclusion after deserializing should be the same",
         )
         self.assertEqual(
             [r.coverage for r in ruleset.rules],
             [r.coverage for r in deserialized_ruleset_full.rules],
-            'Coverages after deserializing should be the same'
+            "Coverages after deserializing should be the same",
         )
         self.assertEqual(
             [r.voting_weight for r in ruleset.rules],
             [r.voting_weight for r in deserialized_ruleset_full.rules],
-            'Voting weights after deserializing should be the same'
+            "Voting weights after deserializing should be the same",
         )
         self.assertTrue(
             compare_survival_prediction(
                 deserialized_ruleset_full.predict(X).tolist(),
                 ruleset.predict(X).tolist(),
             ),
-            'Prediction after deserializing should be the same'
+            "Prediction after deserializing should be the same",
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/base_tests/survival/test_ruleset.py
+++ b/tests/base_tests/survival/test_ruleset.py
@@ -5,9 +5,8 @@ import unittest
 
 import numpy as np
 import pandas as pd
-from decision_rules.core.ruleset import InvalidStateError
+
 from decision_rules.serialization.utils import JSONSerializer
-from decision_rules.survival.ruleset import SurvivalConclusion
 from decision_rules.survival.ruleset import SurvivalRuleSet
 from tests.helpers import compare_survival_prediction
 from tests.loaders import load_resources_path
@@ -16,19 +15,18 @@ from tests.loaders import load_resources_path
 class TestSurvivalRuleSet(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.df = pd.read_csv(os.path.join(
-            load_resources_path(), 'survival', 'BHS.csv'
-        ))
-        self.X = self.df.drop('survival_status', axis=1)
-        self.y = self.df['survival_status'].astype(int).astype(str)
+        self.df = pd.read_csv(
+            os.path.join(load_resources_path(), "survival", "BHS.csv")
+        )
+        self.X = self.df.drop("survival_status", axis=1)
+        self.y = self.df["survival_status"].astype(int).astype(str)
 
         ruleset_file_path: str = os.path.join(
-            load_resources_path(), 'survival', 'BHS_ruleset.json'
+            load_resources_path(), "survival", "BHS_ruleset.json"
         )
-        with open(ruleset_file_path, 'r', encoding='utf-8') as file:
+        with open(ruleset_file_path, "r", encoding="utf-8") as file:
             self.ruleset: SurvivalRuleSet = JSONSerializer.deserialize(
-                json.load(file),
-                SurvivalRuleSet
+                json.load(file), SurvivalRuleSet
             )
 
     def test_calculating_ibs(self):
@@ -37,43 +35,49 @@ class TestSurvivalRuleSet(unittest.TestCase):
         ibs_rulekit = 0.08616902098503432
 
         self.assertEqual(
-            ibs_calculated, ibs_rulekit,
-            'Should calculate integrated_bier_score correctly'
+            ibs_calculated,
+            ibs_rulekit,
+            "Should calculate integrated_bier_score correctly",
         )
 
     def test_prediction(self):
-        df = pd.read_csv(os.path.join(
-            load_resources_path(), 'survival', 'bone-marrow.csv'
-        ))
-        X = df.drop('survival_status', axis=1)
-        y = df['survival_status'].astype(int).astype(str)
+        df = pd.read_csv(
+            os.path.join(load_resources_path(), "survival", "bone-marrow.csv")
+        )
+        X = df.drop("survival_status", axis=1)
+        y = df["survival_status"].astype(int).astype(str)
 
         ruleset_file_path: str = os.path.join(
-            load_resources_path(), 'survival', 'bone-marrow-survival-ruleset.json')
-        with open(ruleset_file_path, 'r', encoding='utf-8') as file:
+            load_resources_path(), "survival", "bone-marrow-survival-ruleset.json"
+        )
+        with open(ruleset_file_path, "r", encoding="utf-8") as file:
             ruleset: SurvivalRuleSet = JSONSerializer.deserialize(
-                json.load(file),
-                SurvivalRuleSet
+                json.load(file), SurvivalRuleSet
             )
         coverage_matrix: np.ndarray = ruleset.update(X, y)
 
         prediction = ruleset.predict(X)
 
-        with open(os.path.join(
-            load_resources_path(), 'survival', 'rulekit-bone-marrow-prediction.json'
-        ), 'r', encoding='utf-8') as file:
+        with open(
+            os.path.join(
+                load_resources_path(), "survival", "rulekit-bone-marrow-prediction.json"
+            ),
+            "r",
+            encoding="utf-8",
+        ) as file:
             rulekit_prediction = np.array(json.load(file))
 
-        self.assertTrue(compare_survival_prediction(
-            prediction, rulekit_prediction
-        ),  'Prediction should be the same as rulekit prediction')
+        self.assertTrue(
+            compare_survival_prediction(prediction, rulekit_prediction),
+            "Prediction should be the same as rulekit prediction",
+        )
 
-        prediction = ruleset.predict_using_coverage_matrix(
-            coverage_matrix)
+        prediction = ruleset.predict_using_coverage_matrix(coverage_matrix)
 
-        self.assertTrue(compare_survival_prediction(
-            prediction, rulekit_prediction
-        ),  'Prediction should be the same as rulekit prediction')
+        self.assertTrue(
+            compare_survival_prediction(prediction, rulekit_prediction),
+            "Prediction should be the same as rulekit prediction",
+        )
 
     def test_different_prediction_strategies(self):
         coverage_matrix: np.ndarray = self.ruleset.update(self.X, self.y)
@@ -84,9 +88,9 @@ class TestSurvivalRuleSet(unittest.TestCase):
             prediction_cov_matrix = self.ruleset.predict_using_coverage_matrix(
                 coverage_matrix
             )
-            self.assertTrue(compare_survival_prediction(
-                prediction, prediction_cov_matrix
-            ))
+            self.assertTrue(
+                compare_survival_prediction(prediction, prediction_cov_matrix)
+            )
 
     def test_condition_importances(self):
         self.ruleset.update(self.X, self.y)
@@ -95,30 +99,37 @@ class TestSurvivalRuleSet(unittest.TestCase):
             self.ruleset.set_prediction_strategy(strategy)
 
             condition_importances = self.ruleset.calculate_condition_importances(
-                self.X, self.y)
+                self.X, self.y
+            )
             attribute_importances = self.ruleset.calculate_attribute_importances(
-                condition_importances)
+                condition_importances
+            )
 
             condition_importances_file_path: str = os.path.join(
-                load_resources_path(), 'survival', 'BHS_condition_importances.json')
-            with open(condition_importances_file_path, 'r', encoding='utf-8') as file:
+                load_resources_path(), "survival", "BHS_condition_importances.json"
+            )
+            with open(condition_importances_file_path, "r", encoding="utf-8") as file:
                 condition_importances_read = json.load(file)
 
             attribute_importances_file_path: str = os.path.join(
-                load_resources_path(), 'survival', 'BHS_attribute_importances.json')
-            with open(attribute_importances_file_path, 'r', encoding='utf-8') as file:
+                load_resources_path(), "survival", "BHS_attribute_importances.json"
+            )
+            with open(attribute_importances_file_path, "r", encoding="utf-8") as file:
                 attribute_importances_read = json.load(file)
 
             condition_importances = pd.DataFrame(condition_importances).round(10)
-            condition_importances_read = pd.DataFrame(condition_importances_read).round(10)
+            condition_importances_read = pd.DataFrame(condition_importances_read).round(
+                10
+            )
             self.assertTrue(
                 (condition_importances == condition_importances_read).all().all(),
-                'Condition importances should be the same as saved before'
+                "Condition importances should be the same as saved before",
             )
 
             self.assertEqual(
-                attribute_importances, attribute_importances_read,
-                'Attribute importances should be the same as saved before'
+                attribute_importances,
+                attribute_importances_read,
+                "Attribute importances should be the same as saved before",
             )
 
     def test_local_explainability(self):
@@ -130,19 +141,28 @@ class TestSurvivalRuleSet(unittest.TestCase):
             rules_covering = res[0]
             kaplan_meier = res[1]
 
-            self.assertEqual(len(rules_covering), 2,
-                             'There should be 2 rules covering instance')
-            self.assertTrue(all(kaplan_meier['probabilities']) >= 0 and all(
-                kaplan_meier['probabilities']) <= 1)
+            self.assertEqual(
+                len(rules_covering), 2, "There should be 2 rules covering instance"
+            )
+            self.assertTrue(
+                all(kaplan_meier["probabilities"]) >= 0
+                and all(kaplan_meier["probabilities"]) <= 1
+            )
 
     def test_survival_status_validation(self):
         self.y = self.y.astype(int)
-        with self.assertRaises(ValueError, msg='Should fail for survival status of type different than string'):
+        with self.assertRaises(
+            ValueError,
+            msg="Should fail for survival status of type different than string",
+        ):
             self.ruleset.update(self.X, self.y)
 
         self.y = self.y.astype(str)
-        self.y.iloc[0] = '-1'
-        with self.assertRaises(ValueError, msg='Should fail for survival status with values different than 0 and 1'):
+        self.y.iloc[0] = "-1"
+        with self.assertRaises(
+            ValueError,
+            msg="Should fail for survival status with values different than 0 and 1",
+        ):
             self.ruleset.update(self.X, self.y)
 
     def test_prediction_with_empty_default_conclusion(self):
@@ -154,9 +174,9 @@ class TestSurvivalRuleSet(unittest.TestCase):
         prediction: np.ndarray = self.ruleset.predict(self.X)
         self.assertTrue(
             any(e is None for e in prediction),
-            'Prediction for some examples should be empty'
+            "Prediction for some examples should be empty",
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/base_tests/survival/test_ruleset.py
+++ b/tests/base_tests/survival/test_ruleset.py
@@ -145,13 +145,6 @@ class TestSurvivalRuleSet(unittest.TestCase):
         with self.assertRaises(ValueError, msg='Should fail for survival status with values different than 0 and 1'):
             self.ruleset.update(self.X, self.y)
 
-    def test_if_prediction_without_update_fails_with_meaningful_error(self):
-        with self.assertRaises(
-            InvalidStateError,
-            msg='Should fail for prediction without update with meaningful error'
-        ):
-            self.ruleset.predict(self.X)
-
     def test_prediction_with_empty_default_conclusion(self):
         # remove one rule to leave some example uncovered
         self.ruleset.rules = self.ruleset.rules[1:2]

--- a/tests/extras/ruleset_factories/rulekit/test_survival.py
+++ b/tests/extras/ruleset_factories/rulekit/test_survival.py
@@ -6,12 +6,14 @@ from typing import Tuple
 
 import numpy as np
 import pandas as pd
+from rulekit.survival import SurvivalRules
+
 from decision_rules.ruleset_factories import ruleset_factory
 from decision_rules.serialization import JSONSerializer
 from decision_rules.survival.ruleset import SurvivalRuleSet
-from rulekit.survival import SurvivalRules
+from tests.loaders import (load_dataset_to_x_y,
+                           load_ruleset_factories_resources_path)
 
-from tests.loaders import load_dataset_to_x_y, load_ruleset_factories_resources_path
 from .helpers import compare_survival_prediction
 
 


### PR DESCRIPTION
Calling the ruleset's `update` method is no longer required after deserializing the model. Prior to these changes, the user had to manually call update on each deserialized ruleset object, passing it the full training dataset. Otherwise, the model was in an incomplete state, and calling some of its methods caused exceptions.

In this PR, I introduced two available serialization modes: 
* `full` - serializes all model information, so it is ready for use after deserialization, no need to call the update method;
* `minimal` - serializes only minimal key information, after deserialization the user must call the update method (works the same as before these changes);

The default serialization mode is `full`, so by default no update is needed after deserialization. The mode can be configured using the `decision_rules.serialization.JSONSerializer.serialize` method, example below:
```python
# using enum (recommended)
from decision_rules.serialization import SerializationModes

JSONSerializer.serialize(ruleset, mode=SerializationModes.FULL)
JSONSerializer.serialize(ruleset, mode=SerializationModes.MINIMAL)

# using the mode name
JSONSerializer.serialize(ruleset, mode='full')
JSONSerializer.serialize(ruleset, mode='minimal')

# will use the default mode “full”
JSONSerializer.serialize(ruleset)
```

It is important to say that the “full” mode can significantly increase the resulting size of json files. For classification and regression rule sets, the difference may be negligible, but for survival rule sets, the size may even double.
