### PR TITLE
build: update setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     extras_require={
         "ruleset_factories": [
-            "rulekit==2.1.21"
+            "rulekit>=2.1.21"
         ]
     },
     python_requires='>=3.9',


### PR DESCRIPTION
Allow newer versions of the rulekit package (>= 2.1.21.0).