### PR TITLE
Fix legacy deserialization bug

### DIFF
--- a/decision_rules/ruleset_factories/__init__.py
+++ b/decision_rules/ruleset_factories/__init__.py
@@ -1,3 +1,5 @@
+from ._factories.classification.mlrules_factory import MLRulesRuleSetFactory
+
 try:
     from ._factory import ruleset_factory
 except ImportError as e:

--- a/decision_rules/serialization/utils.py
+++ b/decision_rules/serialization/utils.py
@@ -201,8 +201,14 @@ class JSONClassSerializer(ABC):
         """
         if data is None:
             return None
-        if not issubclass(data.__class__, BaseModel):
-            data = getattr(cls, "_Model")(**data)
+        model_class: Type[BaseModel] = getattr(cls, "_Model")
+        if not isinstance(data, model_class):
+            if isinstance(data, dict):
+                data: BaseModel = model_class(**data)
+            elif isinstance(data, BaseModel):
+                data: BaseModel = model_class(**data.model_dump())
+            else:
+                raise ValueError("data should be either dict or pydantic model")
         return cls._from_pydantic_model(data)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     ),
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    version='1.2.0',
+    version='1.3.1',
     author='Cezary Maszczyk, Dawid Macha, Adam Grzelak, Bartosz Piguła',
     author_email='cezary.maszczyk@emag.lukasiewicz.gov.pl',
     readme='README.md',

--- a/tests/base_tests/serialization/classification/test_rule_serializer.py
+++ b/tests/base_tests/serialization/classification/test_rule_serializer.py
@@ -1,97 +1,130 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 import unittest
+from typing import Any
 
-from decision_rules.classification.rule import ClassificationConclusion
-from decision_rules.classification.rule import ClassificationRule
-from decision_rules.conditions import AttributesCondition
-from decision_rules.conditions import CompoundCondition
-from decision_rules.conditions import ElementaryCondition
-from decision_rules.conditions import LogicOperators
-from decision_rules.conditions import NominalCondition
+from pydantic import BaseModel
+
+from decision_rules.classification.rule import (ClassificationConclusion,
+                                                ClassificationRule)
+from decision_rules.conditions import (AttributesCondition, CompoundCondition,
+                                       ElementaryCondition, LogicOperators,
+                                       NominalCondition)
 from decision_rules.core.coverage import Coverage
 from decision_rules.serialization import JSONSerializer
 
 
 class TestClassificationRuleSerializer(unittest.TestCase):
 
-    def test_serializing_deserializing(self):
+    def get_test_rule(self) -> ClassificationRule:
         rule = ClassificationRule(
             CompoundCondition(
                 subconditions=[
-                    AttributesCondition(
-                        column_left=2, column_right=3, operator='>'
-                    ),
+                    AttributesCondition(column_left=2, column_right=3, operator=">"),
                     ElementaryCondition(
-                        column_index=2, left=-1, right=2.0, left_closed=True, right_closed=False
+                        column_index=2,
+                        left=-1,
+                        right=2.0,
+                        left_closed=True,
+                        right_closed=False,
                     ),
                     NominalCondition(
                         column_index=2,
-                        value='value',
-                    )
+                        value="value",
+                    ),
                 ],
-                logic_operator=LogicOperators.ALTERNATIVE
+                logic_operator=LogicOperators.ALTERNATIVE,
             ),
-            conclusion=ClassificationConclusion(
-                value=2,
-                column_name='class'
-            ),
-            column_names=list(range(4))
+            conclusion=ClassificationConclusion(value=2, column_name="class"),
+            column_names=list(range(4)),
         )
         rule.coverage = Coverage(p=10, n=2, P=12, N=20)
+        return rule
+
+    def test_serializing_deserializing(self):
+        rule: ClassificationRule = self.get_test_rule()
 
         serialized_rule = JSONSerializer.serialize(rule)
         deserializer_rule: ClassificationRule = JSONSerializer.deserialize(
-            serialized_rule,
-            ClassificationRule
+            serialized_rule, ClassificationRule
         )
         # column_names cannot be populated while deserializing rule without ruleset
         rule.column_names = []
         # P and N cannot be populated while deserializing rule without ruleset
         rule.coverage.P = None
         rule.coverage.N = None
-        deserializer_rule.conclusion.column_name = 'class'
+        deserializer_rule.conclusion.column_name = "class"
         self.assertEqual(
-            rule, deserializer_rule,
-            'Serializing and deserializing should lead to the the same object'
+            rule,
+            deserializer_rule,
+            "Serializing and deserializing should lead to the the same object",
         )
 
-    def test_serializing_deserializing_without_coverage(self):
-        rule = ClassificationRule(
-            CompoundCondition(
-                subconditions=[
-                    AttributesCondition(
-                        column_left=2, column_right=3, operator='>'
-                    ),
-                    ElementaryCondition(
-                        column_index=2, left=-1, right=2.0, left_closed=True, right_closed=False
-                    ),
-                    NominalCondition(
-                        column_index=2,
-                        value='value',
-                    )
-                ],
-                logic_operator=LogicOperators.ALTERNATIVE
-            ),
-            conclusion=ClassificationConclusion(
-                value=2,
-                column_name='class'
-            ),
-            column_names=list(range(4))
-        )
+    def test_serializing_without_coverage(self):
+        rule: ClassificationRule = self.get_test_rule()
+        rule.coverage = None
 
-        serialized_rule = JSONSerializer.serialize(rule)
+        serialized_rule: dict = JSONSerializer.serialize(rule)
         deserializer_rule: ClassificationRule = JSONSerializer.deserialize(
-            serialized_rule,
-            ClassificationRule
+            serialized_rule, ClassificationRule
         )
         # column_names cannot be populated while deserializing rule without ruleset
         rule.column_names = []
-        deserializer_rule.conclusion.column_name = 'class'
+        deserializer_rule.conclusion.column_name = "class"
         self.assertEqual(
-            rule, deserializer_rule,
-            'Serializing and deserializing should lead to the the same object'
+            rule,
+            deserializer_rule,
+            "Serializing and deserializing should lead to the the same object",
+        )
+
+    def test_deserializing_without_coverage(self):
+        rule: ClassificationRule = self.get_test_rule()
+        serialized_rule: dict = JSONSerializer.serialize(rule)
+        # remove coverage info from serialized rule
+        del serialized_rule["coverage"]
+        deserializer_rule: ClassificationRule = JSONSerializer.deserialize(
+            serialized_rule, ClassificationRule
+        )
+        # column_names cannot be populated while deserializing rule without ruleset
+        rule.column_names = []
+        deserializer_rule.conclusion.column_name = "class"
+        self.assertEqual(
+            rule,
+            deserializer_rule,
+            "Serializing and deserializing should lead to the the same object",
+        )
+
+    def test_deserializing_incomplete_pydantic_model(self):
+        """Test fix for ROLAP-2149"""
+
+        class IncompleteClassificationRuleModel(BaseModel):
+            uuid: str
+            string: str
+            premise: Any
+            conclusion: Any
+            coverage: Any = None
+            # voting_weight: Optional[float] = None <-- Drop this field
+
+        rule: ClassificationRule = self.get_test_rule()
+        incomplete_rule_model: ClassificationRule = IncompleteClassificationRuleModel(
+            uuid=rule.uuid,
+            string=str(rule),
+            premise=JSONSerializer.serialize(rule.premise),
+            conclusion=JSONSerializer.serialize(rule.conclusion),
+            coverage=JSONSerializer.serialize(rule.coverage),
+        )
+
+        deserializer_rule: ClassificationRule = JSONSerializer.deserialize(
+            incomplete_rule_model, ClassificationRule
+        )
+        # column_names cannot be populated while deserializing rule without ruleset
+        rule.column_names = []
+        deserializer_rule.conclusion.column_name = "class"
+        self.assertEqual(
+            rule,
+            deserializer_rule,
+            "Serializing and deserializing should lead to the the same object",
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request fix an interesting bug occuring when trying to deserialize custom pydantic model instance using `JSONSerializer.deserialize` method. If the model class was identical as the internal pydantic model class declared inside class serializer, everything worked fine. However when using custom model class which doesn't have some of the fields marked as `Optional` in the internal model, an AttributeErrro occured `ModelClassName object has no attribute 'name_of_the_field`. For an example of this error see `tests.base_tests.serialization.classification.test_rule_serializer.test_deserializing_incomplete_pydantic_model`

Now when you pass pydantic model instance to the `JSONSerializer.deserialize` method, it starts by creating a new pydantic model instance (of the internal pydantic model class declared inside class serializer). If this step fails it means that the model instance passed to the method is incompatible with the desired one. This approach won't fail if the passed object instance won't have some fields which are `Optional`. 