### PR TITLE
refactor: Refactor ruleset_factory package so it does not require rul…

### DIFF
--- a/.github/workflows/unittests-on-pull-request.yml
+++ b/.github/workflows/unittests-on-pull-request.yml
@@ -26,6 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
 
+        pip install rulekit
+
     - name: Run tests for the base package
       run: |
         python -m unittest discover ./tests/base_tests

--- a/README.md
+++ b/README.md
@@ -18,24 +18,14 @@ Functionalities includes, but is not limited to:
 - comparison between rules (semantic and syntactic)
 
 ## Installation
-Base package can be installed from [PyPi](https://pypi.org/project/decision-rules/):
+Package can be installed from [PyPi](https://pypi.org/project/decision-rules/):
 ```
 pip install decision-rules
-```
-
-Besides the base package, additional dependencies are required to use the `ruleset_factories` module. To install these extras, run:
-```
-pip install decision-rules[ruleset_factories]
 ```
 
 You can also just clone the repository and install the package locally:
 ```
 pip install .
-```
-
-or with the extras:
-```
-pip install .[ruleset_factories]
 ```
 
 ## Extras

--- a/decision_rules/ruleset_factories/__init__.py
+++ b/decision_rules/ruleset_factories/__init__.py
@@ -1,9 +1,2 @@
 from ._factories.classification.mlrules_factory import MLRulesRuleSetFactory
-
-try:
-    from ._factory import ruleset_factory
-except ImportError as e:
-    raise ImportError(
-        "The 'ruleset_factories' extra requires some additional dependencies. "
-        "Please install them with: `pip install decision_rules[ruleset_factories]`"
-    ) from e
+from ._factory import ruleset_factory

--- a/decision_rules/ruleset_factories/_factories/classification/__init__.py
+++ b/decision_rules/ruleset_factories/_factories/classification/__init__.py
@@ -1,3 +1,6 @@
-from decision_rules.ruleset_factories._factories.classification.mlrules_factory import MLRulesRuleSetFactory
-from decision_rules.ruleset_factories._factories.classification.rulekit_factory import RuleKitRuleSetFactory
-from decision_rules.ruleset_factories._factories.classification.text_factory import TextRuleSetFactory
+from decision_rules.ruleset_factories._factories.classification.mlrules_factory import \
+    MLRulesRuleSetFactory
+from decision_rules.ruleset_factories._factories.classification.rulekit_factory import \
+    get_rulekit_factory_class
+from decision_rules.ruleset_factories._factories.classification.text_factory import \
+    TextRuleSetFactory

--- a/decision_rules/ruleset_factories/_factories/classification/rulekit_factory.py
+++ b/decision_rules/ruleset_factories/_factories/classification/rulekit_factory.py
@@ -1,70 +1,71 @@
 # pylint: disable=protected-access
-from typing import List
+from typing import List, Type
 
 import pandas as pd
-from rulekit.classification import RuleClassifier
-from rulekit.rules import BaseRule as RuleKitRule
 
-from decision_rules.classification.rule import ClassificationConclusion
-from decision_rules.classification.rule import ClassificationRule
+from decision_rules.classification.rule import (ClassificationConclusion,
+                                                ClassificationRule)
 from decision_rules.classification.ruleset import ClassificationRuleSet
-from decision_rules.ruleset_factories.utils.abstract_rulekit_factory import AbstractRuleKitRuleSetFactory
+from decision_rules.ruleset_factories._factories.abstract_factory import \
+    AbstractFactory
+from decision_rules.ruleset_factories.utils.abstract_rulekit_factory import (  # pylint: disable=import-outside-toplevel
+    AbstractRuleKitRuleSetFactory,
+    check_if_rulekit_is_installed_and_correct_version)
 
 
-class RuleKitRuleSetFactory(AbstractRuleKitRuleSetFactory):
-    """Generates classification ruleset from RuleKit RuleClassifier
-    """
+def get_rulekit_factory_class() -> Type[AbstractFactory]:
+    check_if_rulekit_is_installed_and_correct_version()
 
-    def make(
-        self,
-        model: RuleClassifier,
-        X_train: pd.DataFrame,
-        y_train: pd.Series
-    ) -> ClassificationRuleSet:
-        ruleset: ClassificationRuleSet = super().make(
-            model, X_train, y_train
-        )
-        ruleset.y_values = self.labels_values
-        return ruleset
+    from rulekit.classification import \
+        RuleClassifier  # pylint: disable=import-outside-toplevel
+    from rulekit.rules import \
+        BaseRule as RuleKitRule  # pylint: disable=import-outside-toplevel
 
-    def _make_ruleset(self, rules: List[ClassificationRule]) -> ClassificationRuleSet:
-        return ClassificationRuleSet(rules)
+    class RuleKitRuleSetFactory(AbstractRuleKitRuleSetFactory):
+        """Generates classification ruleset from RuleKit RuleClassifier"""
 
-    def _make_rule(self, rule: RuleKitRule) -> ClassificationRule:
-        return ClassificationRule(
-            premise=self._make_rule_premise(rule),
-            conclusion=self._make_rule_conclusion(rule),
-            column_names=self.columns_names)
+        def make(
+            self, model: RuleClassifier, X_train: pd.DataFrame, y_train: pd.Series
+        ) -> ClassificationRuleSet:
+            ruleset: ClassificationRuleSet = super().make(model, X_train, y_train)
+            ruleset.y_values = self.labels_values
+            return ruleset
 
-    def _make_rule_conclusion(self, rule: RuleKitRule) -> ClassificationConclusion:
-        consequence = rule._java_object.getConsequence()
-        consequence_mapping = consequence.getValueSet().getMapping()
-        decision_value = consequence.getValueSet().getValue()
-        if consequence_mapping is not None:
-            decision_value = consequence_mapping.get(int(decision_value))
-            if decision_value.__class__.__name__ == 'java.lang.String':
-                decision_value = str(decision_value)
-            else:
-                decision_value = int(decision_value)
-        decision_attribute_name = str(consequence.getAttribute())
-        return ClassificationConclusion(decision_value, decision_attribute_name)
+        def _make_ruleset(
+            self, rules: List[ClassificationRule]
+        ) -> ClassificationRuleSet:
+            return ClassificationRuleSet(rules)
 
-    def _calculate_P_N(
-        self,
-        model: RuleClassifier,
-        ruleset: ClassificationRuleSet
-    ):
-        P = {
-            y_value: 0 for y_value in self.labels_values
-        }
-        N = {
-            y_value: 0 for y_value in self.labels_values
-        }
-        for rule in model.model.rules:
-            decision = int(
-                rule._java_object.getConsequence().getValueSet().getValue()
+        def _make_rule(self, rule: RuleKitRule) -> ClassificationRule:
+            return ClassificationRule(
+                premise=self._make_rule_premise(rule),
+                conclusion=self._make_rule_conclusion(rule),
+                column_names=self.columns_names,
             )
-            N[decision] = rule.weighted_N
-            P[decision] = rule.weighted_P
-        ruleset.train_P = P
-        ruleset.train_N = N
+
+        def _make_rule_conclusion(self, rule: RuleKitRule) -> ClassificationConclusion:
+            consequence = rule._java_object.getConsequence()
+            consequence_mapping = consequence.getValueSet().getMapping()
+            decision_value = consequence.getValueSet().getValue()
+            if consequence_mapping is not None:
+                decision_value = consequence_mapping.get(int(decision_value))
+                if decision_value.__class__.__name__ == "java.lang.String":
+                    decision_value = str(decision_value)
+                else:
+                    decision_value = int(decision_value)
+            decision_attribute_name = str(consequence.getAttribute())
+            return ClassificationConclusion(decision_value, decision_attribute_name)
+
+        def _calculate_P_N(self, model: RuleClassifier, ruleset: ClassificationRuleSet):
+            P = {y_value: 0 for y_value in self.labels_values}
+            N = {y_value: 0 for y_value in self.labels_values}
+            for rule in model.model.rules:
+                decision = int(
+                    rule._java_object.getConsequence().getValueSet().getValue()
+                )
+                N[decision] = rule.weighted_N
+                P[decision] = rule.weighted_P
+            ruleset.train_P = P
+            ruleset.train_N = N
+
+    return RuleKitRuleSetFactory

--- a/decision_rules/ruleset_factories/_factories/regression/__init__.py
+++ b/decision_rules/ruleset_factories/_factories/regression/__init__.py
@@ -1,2 +1,4 @@
-from decision_rules.ruleset_factories._factories.regression.rulekit_factory import RuleKitRuleSetFactory
-from decision_rules.ruleset_factories._factories.regression.text_factory import TextRuleSetFactory
+from decision_rules.ruleset_factories._factories.regression.rulekit_factory import \
+    get_rulekit_factory_class
+from decision_rules.ruleset_factories._factories.regression.text_factory import \
+    TextRuleSetFactory

--- a/decision_rules/ruleset_factories/_factories/regression/rulekit_factory.py
+++ b/decision_rules/ruleset_factories/_factories/regression/rulekit_factory.py
@@ -1,50 +1,57 @@
 # pylint: disable=protected-access
-from typing import List
+from typing import List, Type
 
-from pandas import DataFrame
-from pandas import Series
-from rulekit.regression import RuleRegressor
-from rulekit.rules import BaseRule as RuleKitRule
+from pandas import DataFrame, Series
 
 from decision_rules.core.ruleset import AbstractRuleSet
-from decision_rules.regression.rule import RegressionConclusion
-from decision_rules.regression.rule import RegressionRule
+from decision_rules.regression.rule import RegressionConclusion, RegressionRule
 from decision_rules.regression.ruleset import RegressionRuleSet
-from decision_rules.ruleset_factories.utils.abstract_rulekit_factory import AbstractRuleKitRuleSetFactory
+from decision_rules.ruleset_factories._factories.abstract_factory import \
+    AbstractFactory
+from decision_rules.ruleset_factories.utils.abstract_rulekit_factory import (  # pylint: disable=import-outside-toplevel
+    AbstractRuleKitRuleSetFactory,
+    check_if_rulekit_is_installed_and_correct_version)
 
 
-class RuleKitRuleSetFactory(AbstractRuleKitRuleSetFactory):
-    """Generates regression ruleset from RuleKit RuleRegressor
-    """
+def get_rulekit_factory_class() -> Type[AbstractFactory]:
+    check_if_rulekit_is_installed_and_correct_version()
 
-    def _make_ruleset(self, rules: List[RegressionRule]) -> RegressionRuleSet:
-        return RegressionRuleSet(rules)
+    from rulekit.regression import \
+        RuleRegressor  # pylint: disable=import-outside-toplevel
+    from rulekit.rules import \
+        BaseRule as RuleKitRule  # pylint: disable=import-outside-toplevel
 
-    def _make_rule(self, rule: RuleKitRule) -> RegressionRule:
-        return RegressionRule(
-            premise=self._make_rule_premise(rule),
-            conclusion=self._make_rule_conclusion(rule),
-            column_names=self.columns_names
-        )
+    class RuleKitRuleSetFactory(AbstractRuleKitRuleSetFactory):
+        """Generates regression ruleset from RuleKit RuleRegressor"""
 
-    def _make_rule_conclusion(self, rule: RuleKitRule) -> RegressionConclusion:
-        consequence = rule._java_object.getConsequence()
-        decision_value = consequence.getValueSet().getValue()
-        decision_attribute_name = str(consequence.getAttribute())
-        return RegressionConclusion(decision_value, decision_attribute_name)
+        def _make_ruleset(self, rules: List[RegressionRule]) -> RegressionRuleSet:
+            return RegressionRuleSet(rules)
 
-    def _calculate_P_N(
-        self,
-        model: RuleRegressor,
-        ruleset: RegressionRuleSet
-    ):
-        pass
-
-    def make(self, model: RuleRegressor, X_train: DataFrame, y_train: Series) -> AbstractRuleSet:
-        if not model.get_params().get('mean_based_regression', False):
-            raise NotImplementedError(
-                'ruleset_factories package does not support median based regression any more.' +
-                'use "mean_based_regression" parameter of RuleRegressor class to enable mean ' +
-                'based regression.'
+        def _make_rule(self, rule: RuleKitRule) -> RegressionRule:
+            return RegressionRule(
+                premise=self._make_rule_premise(rule),
+                conclusion=self._make_rule_conclusion(rule),
+                column_names=self.columns_names,
             )
-        return super().make(model, X_train, y_train)
+
+        def _make_rule_conclusion(self, rule: RuleKitRule) -> RegressionConclusion:
+            consequence = rule._java_object.getConsequence()
+            decision_value = consequence.getValueSet().getValue()
+            decision_attribute_name = str(consequence.getAttribute())
+            return RegressionConclusion(decision_value, decision_attribute_name)
+
+        def _calculate_P_N(self, model: RuleRegressor, ruleset: RegressionRuleSet):
+            pass
+
+        def make(
+            self, model: RuleRegressor, X_train: DataFrame, y_train: Series
+        ) -> AbstractRuleSet:
+            if not model.get_params().get("mean_based_regression", False):
+                raise NotImplementedError(
+                    "ruleset_factories package does not support median based regression any more."
+                    + 'use "mean_based_regression" parameter of RuleRegressor class to enable mean '
+                    + "based regression."
+                )
+            return super().make(model, X_train, y_train)
+
+    return RuleKitRuleSetFactory

--- a/decision_rules/ruleset_factories/_factories/survival/__init__.py
+++ b/decision_rules/ruleset_factories/_factories/survival/__init__.py
@@ -1,2 +1,4 @@
-from decision_rules.ruleset_factories._factories.survival.rulekit_factory import RuleKitRuleSetFactory
-from decision_rules.ruleset_factories._factories.survival.text_factory import TextRuleSetFactory
+from decision_rules.ruleset_factories._factories.survival.rulekit_factory import \
+    get_rulekit_factory_class
+from decision_rules.ruleset_factories._factories.survival.text_factory import \
+    TextRuleSetFactory

--- a/decision_rules/ruleset_factories/_factory.py
+++ b/decision_rules/ruleset_factories/_factory.py
@@ -1,14 +1,15 @@
 from typing import Any
 
 import pandas as pd
-from decision_rules.core.ruleset import AbstractRuleSet
+
 import decision_rules.ruleset_factories._factories as factories
+from decision_rules.core.ruleset import AbstractRuleSet
+from decision_rules.ruleset_factories._factories.abstract_factory import \
+    AbstractFactory
 
 
 def ruleset_factory(
-    model: Any,
-    X_train: pd.DataFrame,
-    y_train: pd.Series
+    model: Any, X_train: pd.DataFrame, y_train: pd.Series
 ) -> AbstractRuleSet:
     """Creates editable ruleset model from rule-based model
     from various ML packages.
@@ -28,17 +29,16 @@ def ruleset_factory(
     # get class name
     model_class_name: str = model.__class__.__name__
     # get also names of parent classes (in case it is an expert induction model)
-    model_parent_names: list[str] = [
-        cls.__name__ for cls in model.__class__.mro()]
+    model_parent_names: list[str] = [cls.__name__ for cls in model.__class__.mro()]
     class_names = [model_class_name] + model_parent_names
-    if 'RuleClassifier' in class_names:
-        factory = factories.classification.RuleKitRuleSetFactory()
-    elif 'RuleRegressor' in class_names:
-        factory = factories.regression.RuleKitRuleSetFactory()
-    elif 'SurvivalRules' in class_names:
-        factory = factories.survival.RuleKitRuleSetFactory()
-    else:
-        raise ValueError(
-            f'No ruleset factory class for type: "{model_class_name}"'
+    if "RuleClassifier" in class_names:
+        factory: AbstractFactory = (
+            factories.classification.get_rulekit_factory_class()()
         )
+    elif "RuleRegressor" in class_names:
+        factory: AbstractFactory = factories.regression.get_rulekit_factory_class()()
+    elif "SurvivalRules" in class_names:
+        factory: AbstractFactory = factories.survival.get_rulekit_factory_class()()
+    else:
+        raise ValueError(f'No ruleset factory class for type: "{model_class_name}"')
     return factory.make(model, X_train, y_train)

--- a/decision_rules/ruleset_factories/utils/abstract_rulekit_factory.py
+++ b/decision_rules/ruleset_factories/utils/abstract_rulekit_factory.py
@@ -1,88 +1,85 @@
 from abc import abstractmethod
-from typing import Any
-from typing import Callable
-from typing import Iterable
-from typing import Optional
+from enum import Enum
+from typing import Any, Callable, Iterable, Optional
 
+import packaging.version
 import pandas as pd
-from rulekit.params import Measures
-from rulekit.rules import BaseRule as RuleKitRule
 
-from decision_rules.conditions import AbstractCondition
-from decision_rules.conditions import CompoundCondition
-from decision_rules.conditions import ElementaryCondition
-from decision_rules.conditions import LogicOperators
-from decision_rules.conditions import NominalCondition
+from decision_rules.conditions import (AbstractCondition, CompoundCondition,
+                                       ElementaryCondition, LogicOperators,
+                                       NominalCondition)
 from decision_rules.core.coverage import Coverage
-from decision_rules.core.rule import AbstractConclusion
-from decision_rules.core.rule import AbstractRule
+from decision_rules.core.rule import AbstractConclusion, AbstractRule
 from decision_rules.core.ruleset import AbstractRuleSet
 from decision_rules.helpers import get_measure_function_by_name
-from decision_rules.ruleset_factories._factories.abstract_factory import AbstractFactory
+from decision_rules.ruleset_factories._factories.abstract_factory import \
+    AbstractFactory
+
+MINIMUM_RULEKIT_VERSION: str = "2.1.21"
+
+def check_if_rulekit_is_installed_and_correct_version():
+    try:
+        from rulekit import __VERSION__
+    except ImportError as e:
+        raise ImportError(
+            "The 'ruleset_factories' extra requires additional 'rulekit' "
+            "dependencies. Please install them with: `pip install rulekit`"
+        ) from e
+    actual_version = packaging.version.parse(__VERSION__)
+    required_version = packaging.version.parse(MINIMUM_RULEKIT_VERSION)
+    if actual_version < required_version:
+        raise ImportError(
+            "The 'ruleset_factories' extra requires rulekit version 2.1.21 or higher. "
+            f"Currently installed version is { __VERSION__}. "
+            "Please install it with: `pip install rulekit>=2.1.21`"
+        )
 
 
 class AbstractRuleKitRuleSetFactory(AbstractFactory):
 
     def __init__(self) -> None:
+
         self.column_indices: dict = None
         self.columns_names: list[str] = None
         self.labels_values: Iterable[Any] = None
 
-    def make(
-        self,
-        model,
-        X_train: pd.DataFrame,
-        y_train: pd.Series
-    ) -> AbstractRuleSet:
+    def make(self, model, X_train: pd.DataFrame, y_train: pd.Series) -> AbstractRuleSet:
         self.labels_values = y_train.unique()
         self.columns_names = X_train.columns.tolist()
         self.column_indices = {
             column_name: i for i, column_name in enumerate(self.columns_names)
         }
-        ruleset = self._make_ruleset([
-            self._make_rule(rule)
-            for rule in model.model.rules
-        ])
+        ruleset = self._make_ruleset(
+            [self._make_rule(rule) for rule in model.model.rules]
+        )
         self._calculate_P_N(model, ruleset)
         ruleset.column_names = self.columns_names
         ruleset.decision_attribute = y_train.name
 
-        ruleset.update(
-            X_train, y_train,
-            measure=self._get_voting_measure(model)
-        )
+        ruleset.update(X_train, y_train, measure=self._get_voting_measure(model))
         return ruleset
 
     def _get_voting_measure(
         self,
         model,
     ) -> Callable[[Coverage], float]:
-        tmp: Measures = model.get_params()['voting_measure']
+        tmp: Enum = model.get_params()["voting_measure"]
         voting_measure_name: str = tmp.value
         return get_measure_function_by_name(voting_measure_name)
 
     @abstractmethod
-    def _calculate_P_N(
-        self,
-        model,
-        ruleset: AbstractRuleSet
-    ):
+    def _calculate_P_N(self, model, ruleset: AbstractRuleSet):
         pass
 
     def _make_compound_condition(
-            self,
-            parent: Optional[CompoundCondition],
-            java_object: Any
+        self, parent: Optional[CompoundCondition], java_object: Any
     ) -> CompoundCondition:
-        if 'OR' in str(java_object.toString()):
+        if "OR" in str(java_object.toString()):
             operator = LogicOperators.ALTERNATIVE
         else:
             operator = LogicOperators.CONJUNCTION
 
-        condition = CompoundCondition(
-            subconditions=[],
-            logic_operator=operator
-        )
+        condition = CompoundCondition(subconditions=[], logic_operator=operator)
         subconditions = java_object.getSubconditions()
         for subcondition in subconditions:
             self._make_condition(condition, subcondition)
@@ -104,66 +101,61 @@ class AbstractRuleKitRuleSetFactory(AbstractFactory):
         value_set = java_object.getValueSet()
         condition = NominalCondition(
             column_index=self.column_indices[java_object.getAttribute()],
-            value=str(value_set.getMapping().get(int(value_set.getValue())))
+            value=str(value_set.getMapping().get(int(value_set.getValue()))),
         )
         condition.negated = negated
         parent.subconditions.append(condition)
         return condition
 
     def _make_numerical_condition(
-        self,
-        parent: Optional[CompoundCondition],
-        java_object: Any
+        self, parent: Optional[CompoundCondition], java_object: Any
     ) -> NominalCondition:
         value_set = java_object.getValueSet()
         value_set_str = str(value_set)
         left = float(value_set.getLeft())
         if left == -value_set.INF:
-            left = float('-inf')
+            left = float("-inf")
         right = float(value_set.getRight())
         if right == value_set.INF:
-            right = float('inf')
+            right = float("inf")
         condition = ElementaryCondition(
             column_index=self.column_indices[java_object.getAttribute()],
             left=left,
             right=right,
-            left_closed=value_set_str.startswith('<'),
-            right_closed=value_set_str.endswith('>')
+            left_closed=value_set_str.startswith("<"),
+            right_closed=value_set_str.endswith(">"),
         )
         parent.subconditions.append(condition)
         return condition
 
     def _make_elementary_condition(
-            self,
-            parent: Optional[CompoundCondition],
-            java_object: Any
+        self, parent: Optional[CompoundCondition], java_object: Any
     ) -> ElementaryCondition:
-        type = str(java_object.getValueSet(
-        ).getClass().getName()).split('.')[-1]
+        type = str(java_object.getValueSet().getClass().getName()).split(".")[-1]
         condition: AbstractCondition = {
-            'SingletonSetComplement': lambda a, b: self._make_nominal_condition(a, b, negated=True),
-            'SingletonSet': lambda a, b: self._make_nominal_condition(a, b),
-            'Interval': lambda a, b: self._make_numerical_condition(a, b),
+            "SingletonSetComplement": lambda a, b: self._make_nominal_condition(
+                a, b, negated=True
+            ),
+            "SingletonSet": lambda a, b: self._make_nominal_condition(a, b),
+            "Interval": lambda a, b: self._make_numerical_condition(a, b),
         }[type](parent, java_object)
         return condition
 
     def _make_condition(
-            self,
-            parent: CompoundCondition,
-            java_object: Any
+        self, parent: CompoundCondition, java_object: Any
     ) -> AbstractCondition:
-        type: str = str(java_object.getClass().getName()).split('.')[-1]
+        type: str = str(java_object.getClass().getName()).split(".")[-1]
         condition: AbstractCondition = {
-            'ElementaryCondition': lambda a, b: self._make_elementary_condition(a, b),
-            'CompoundCondition': lambda a, b: self._make_compound_condition(a, b),
+            "ElementaryCondition": lambda a, b: self._make_elementary_condition(a, b),
+            "CompoundCondition": lambda a, b: self._make_compound_condition(a, b),
         }[type](parent, java_object)
         return condition
 
     def _make_rules(
-            self,
-            model,
+        self,
+        model,
     ) -> list[AbstractRule]:
-        rulekit_rules: list[RuleKitRule] = model.model.rules
+        rulekit_rules: list = model.model.rules
         output_rules: list[AbstractRule] = [
             self._make_rule(rule) for rule in model.model.rules
         ]
@@ -173,7 +165,7 @@ class AbstractRuleKitRuleSetFactory(AbstractFactory):
                 rulekit_rule.weighted_p,
                 rulekit_rule.weighted_n,
                 rulekit_rule.weighted_P,
-                rulekit_rule.weighted_N
+                rulekit_rule.weighted_N,
             )
             output_rules[i].voting_weight = rulekit_rule.weight
         return output_rules
@@ -183,18 +175,17 @@ class AbstractRuleKitRuleSetFactory(AbstractFactory):
         pass
 
     @abstractmethod
-    def _make_rule(self, rule: RuleKitRule) -> AbstractRule:
+    def _make_rule(self, rule) -> AbstractRule:
         pass
 
     @abstractmethod
-    def _make_rule_conclusion(self, rule: RuleKitRule) -> AbstractConclusion:
+    def _make_rule_conclusion(self, rule) -> AbstractConclusion:
         pass
 
-    def _make_rule_premise(self, rule: RuleKitRule) -> AbstractCondition:
+    def _make_rule_premise(self, rule) -> AbstractCondition:
         subconditions = rule._java_object.getPremise().getSubconditions()
         premise = CompoundCondition(
-            subconditions=[],
-            logic_operator=LogicOperators.CONJUNCTION
+            subconditions=[], logic_operator=LogicOperators.CONJUNCTION
         )
         for subcondition in subconditions:
             self._make_condition(premise, subcondition)

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,26 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='decision_rules',
+    name="decision_rules",
     description=(
         "Package implementing decision rules. Includes tools for calculations of various measures "
         "and indicators, as well as algorithms for filtering rulesets."
     ),
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    version='1.3.2',
-    author='Cezary Maszczyk, Dawid Macha, Adam Grzelak, Bartosz Piguła',
-    author_email='cezary.maszczyk@emag.lukasiewicz.gov.pl',
-    readme='README.md',
+    version="1.4.0",
+    author="Cezary Maszczyk, Dawid Macha, Adam Grzelak, Bartosz Piguła",
+    author_email="cezary.maszczyk@emag.lukasiewicz.gov.pl",
+    readme="README.md",
     packages=find_packages(),
     install_requires=[
-        'numpy>=1.24',
-        'pandas>=1.5',
-        'pydantic>=2.0',
-        'scipy>=1.11',
-        'scikit-learn>=1.1',
-        'imbalanced-learn>=0.10',
-        'typeguard>=4.3',
+        "numpy>=1.24",
+        "pandas>=1.5",
+        "pydantic>=2.0",
+        "scipy>=1.11",
+        "scikit-learn>=1.1",
+        "imbalanced-learn>=0.10",
+        "typeguard>=4.3",
     ],
-    extras_require={
-        "ruleset_factories": [
-            "rulekit>=2.1.21"
-        ]
-    },
-    python_requires='>=3.9',
+    python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "scikit-learn>=1.1",
         "imbalanced-learn>=0.10",
         "typeguard>=4.3",
+        "packaging>=14.1"
     ],
     python_requires=">=3.9",
 )


### PR DESCRIPTION
Now you don't need to install the rulekit package to use the decision_rules.ruleset_factories module. Of course, it must be installed to use it in rulekit models, but using other factory classes does not require it.